### PR TITLE
Throw on allocate or acquire errors

### DIFF
--- a/src/proteus/core/worker_info.hpp
+++ b/src/proteus/core/worker_info.hpp
@@ -99,13 +99,13 @@ class WorkerInfo {
    *
    * @param buffer the buffer to return
    */
-  void putInputBuffer(BufferPtrs buffer);
+  void putInputBuffer(BufferPtrs buffer) const;
   /**
    * @brief Return an output buffer to the worker
    *
    * @param buffer the buffer to return
    */
-  void putOutputBuffer(BufferPtrs buffer);
+  void putOutputBuffer(BufferPtrs buffer) const;
 
   /**
    * @brief Checks if this worker group supports a particular number of input
@@ -141,7 +141,7 @@ class WorkerInfo {
   void allocate(size_t request_size);
 
   /// get the number of workers in the group
-  int getGroupSize();
+  size_t getGroupSize() const;
 
   /// get the batch size of the worker group
   [[nodiscard]] auto getBatchSize() const { return this->batch_size_; }
@@ -152,9 +152,9 @@ class WorkerInfo {
   std::vector<std::unique_ptr<Batcher>> batchers_;
   BufferPtrsQueuePtr input_buffer_ptr_;
   BufferPtrsQueuePtr output_buffer_ptr_;
-  size_t buffer_num_;
-  size_t max_buffer_num_;
-  size_t batch_size_;
+  size_t buffer_num_ = 0;
+  size_t max_buffer_num_ = 0;
+  size_t batch_size_ = 1;
 
   friend class Manager;
 };

--- a/tests/src/proteus/core/worker_info_buffers_finite.cpp
+++ b/tests/src/proteus/core/worker_info_buffers_finite.cpp
@@ -66,7 +66,7 @@ void WorkerInfo::joinAll() {}
 
 void WorkerInfo::unload() {}
 
-int WorkerInfo::getGroupSize() { return 1; }
+size_t WorkerInfo::getGroupSize() const { return 1; }
 
 void WorkerInfo::shutdown() {}
 
@@ -82,11 +82,11 @@ BufferPtrs WorkerInfo::getOutputBuffer() const {
   return buffer;
 }
 
-void WorkerInfo::putInputBuffer(BufferPtrs buffer) {
+void WorkerInfo::putInputBuffer(BufferPtrs buffer) const {
   this->input_buffer_ptr_->enqueue(std::move(buffer));
 }
 
-void WorkerInfo::putOutputBuffer(BufferPtrs buffer) {
+void WorkerInfo::putOutputBuffer(BufferPtrs buffer) const {
   this->output_buffer_ptr_->enqueue(std::move(buffer));
 }
 

--- a/tests/src/proteus/core/worker_info_buffers_infinite.cpp
+++ b/tests/src/proteus/core/worker_info_buffers_infinite.cpp
@@ -67,7 +67,7 @@ void WorkerInfo::joinAll() {}
 
 void WorkerInfo::unload() {}
 
-int WorkerInfo::getGroupSize() { return 1; }
+size_t WorkerInfo::getGroupSize() const { return 1; }
 
 void WorkerInfo::shutdown() {}
 
@@ -81,9 +81,9 @@ BufferPtrs WorkerInfo::getOutputBuffer() const {
   return buffer;
 }
 
-void WorkerInfo::putInputBuffer(BufferPtrs buffer) { (void)buffer; }
+void WorkerInfo::putInputBuffer(BufferPtrs buffer) const { (void)buffer; }
 
-void WorkerInfo::putOutputBuffer(BufferPtrs buffer) { (void)buffer; }
+void WorkerInfo::putOutputBuffer(BufferPtrs buffer) const { (void)buffer; }
 
 bool WorkerInfo::inputSizeValid(size_t size) const {
   (void)size;


### PR DESCRIPTION
Style fixes

# Summary of Changes

*  Catch exceptions thrown by `allocate()` and `acquire()` during worker loading

Closes #28 

# Motivation

Loading workers can fail for a variety of reasons. Before, only worker exceptions thrown during `init()` were caught. Now, exceptions thrown in all the initialization methods can be reported back to the client.

# Implementation

Try-catch blocks around the methods in question perform local clean-up and then re-throw the exception. It's eventually caught by the Manager and the error is passed to the client.

Some style changes are also implemented to refactor some code and change some function signatures.
