### PR TITLE
Use better exceptions

### DIFF
--- a/examples/python/custom_processing.py
+++ b/examples/python/custom_processing.py
@@ -108,10 +108,7 @@ def main():
 
     ready = False
     while not ready:
-        try:
-            ready = client.modelReady(worker_name)
-        except proteus.RuntimeError:
-            pass
+        ready = client.modelReady(worker_name)
     # -load worker:
 
     # +get images:

--- a/examples/python/custom_processing.py
+++ b/examples/python/custom_processing.py
@@ -110,7 +110,7 @@ def main():
     while not ready:
         try:
             ready = client.modelReady(worker_name)
-        except proteus.Error:
+        except proteus.RuntimeError:
             pass
     # -load worker:
 

--- a/examples/python/custom_processing.py
+++ b/examples/python/custom_processing.py
@@ -110,7 +110,7 @@ def main():
     while not ready:
         try:
             ready = client.modelReady(worker_name)
-        except RuntimeError:
+        except proteus.Error:
             pass
     # -load worker:
 

--- a/examples/python/custom_processing.py
+++ b/examples/python/custom_processing.py
@@ -110,7 +110,7 @@ def main():
     while not ready:
         try:
             ready = client.modelReady(worker_name)
-        except ValueError:
+        except RuntimeError:
             pass
     # -load worker:
 

--- a/examples/python/hello_world_rest.py
+++ b/examples/python/hello_world_rest.py
@@ -62,7 +62,7 @@ def main():
     while not ready:
         try:
             ready = client.modelReady(worker_name)
-        except proteus.Error:
+        except proteus.RuntimeError:
             pass
     # -load worker:
 

--- a/examples/python/hello_world_rest.py
+++ b/examples/python/hello_world_rest.py
@@ -62,7 +62,7 @@ def main():
     while not ready:
         try:
             ready = client.modelReady(worker_name)
-        except ValueError:
+        except RuntimeError:
             pass
     # -load worker:
 

--- a/examples/python/hello_world_rest.py
+++ b/examples/python/hello_world_rest.py
@@ -60,10 +60,7 @@ def main():
 
     ready = False
     while not ready:
-        try:
-            ready = client.modelReady(worker_name)
-        except proteus.RuntimeError:
-            pass
+        ready = client.modelReady(worker_name)
     # -load worker:
 
     # +inference: construct the request and make the inference

--- a/examples/python/hello_world_rest.py
+++ b/examples/python/hello_world_rest.py
@@ -62,7 +62,7 @@ def main():
     while not ready:
         try:
             ready = client.modelReady(worker_name)
-        except RuntimeError:
+        except proteus.Error:
             pass
     # -load worker:
 

--- a/examples/python/pt_zendnn.py
+++ b/examples/python/pt_zendnn.py
@@ -95,10 +95,7 @@ def main(args):
 
     ready = False
     while not ready:
-        try:
-            ready = client.modelReady(worker_name)
-        except proteus.RuntimeError:
-            pass
+        ready = client.modelReady(worker_name)
 
     # Inference with images
     # If with real data, do preprocessing, otherwise create dummy data

--- a/examples/python/pt_zendnn.py
+++ b/examples/python/pt_zendnn.py
@@ -97,7 +97,7 @@ def main(args):
     while not ready:
         try:
             ready = client.modelReady(worker_name)
-        except RuntimeError:
+        except proteus.Error:
             pass
 
     # Inference with images
@@ -190,7 +190,7 @@ if __name__ == "__main__":
         type=str,
         required=False,
         help="Full path to the input graph",
-        default=os.path.join(root, "external/pytorch_models/resnet50_pretrained.pth"),
+        default=os.path.join(root, "external/pytorch_models/resnet50_pretrained.pt"),
     )
     parser.add_argument(
         "--image_location",

--- a/examples/python/pt_zendnn.py
+++ b/examples/python/pt_zendnn.py
@@ -97,7 +97,7 @@ def main(args):
     while not ready:
         try:
             ready = client.modelReady(worker_name)
-        except proteus.Error:
+        except proteus.RuntimeError:
             pass
 
     # Inference with images

--- a/examples/python/pt_zendnn.py
+++ b/examples/python/pt_zendnn.py
@@ -97,7 +97,7 @@ def main(args):
     while not ready:
         try:
             ready = client.modelReady(worker_name)
-        except ValueError:
+        except RuntimeError:
             pass
 
     # Inference with images

--- a/examples/python/tf_zendnn.py
+++ b/examples/python/tf_zendnn.py
@@ -105,7 +105,7 @@ def main(args):
     while not ready:
         try:
             ready = client.modelReady(worker_name)
-        except RuntimeError:
+        except proteus.Error:
             pass
 
     # Inference with images

--- a/examples/python/tf_zendnn.py
+++ b/examples/python/tf_zendnn.py
@@ -105,7 +105,7 @@ def main(args):
     while not ready:
         try:
             ready = client.modelReady(worker_name)
-        except proteus.Error:
+        except proteus.RuntimeError:
             pass
 
     # Inference with images

--- a/examples/python/tf_zendnn.py
+++ b/examples/python/tf_zendnn.py
@@ -105,7 +105,7 @@ def main(args):
     while not ready:
         try:
             ready = client.modelReady(worker_name)
-        except ValueError:
+        except RuntimeError:
             pass
 
     # Inference with images

--- a/examples/python/tf_zendnn.py
+++ b/examples/python/tf_zendnn.py
@@ -103,10 +103,7 @@ def main(args):
 
     ready = False
     while not ready:
-        try:
-            ready = client.modelReady(worker_name)
-        except proteus.RuntimeError:
-            pass
+        ready = client.modelReady(worker_name)
 
     # Inference with images
     # If with real data, do preprocessing, otherwise create dummy data

--- a/include/proteus/core/data_types.hpp
+++ b/include/proteus/core/data_types.hpp
@@ -26,7 +26,8 @@
 #include <stdexcept>  // for invalid_argument
 #include <string>     // for string
 
-#include "proteus/build_options.hpp"  // for PROTEUS_ENABLE_VITIS
+#include "proteus/build_options.hpp"    // for PROTEUS_ENABLE_VITIS
+#include "proteus/core/exceptions.hpp"  // for invalid_argument
 
 #ifdef PROTEUS_ENABLE_VITIS
 namespace xir {
@@ -114,7 +115,7 @@ class DataType {
       case DataType::STRING:
         return sizeof(std::string);
       default:
-        throw std::invalid_argument("Size requested of unknown data type");
+        throw invalid_argument("Size requested of unknown data type");
     }
   }
 
@@ -152,7 +153,7 @@ class DataType {
       case DataType::STRING:
         return "STRING";
       default:
-        throw std::invalid_argument("String requested of unknown data type");
+        throw invalid_argument("String requested of unknown data type");
     }
   }
 
@@ -188,7 +189,7 @@ class DataType {
       case detail::hash("UNKNOWN"):
         return DataType::UNKNOWN;
       default:
-        throw std::invalid_argument("Unknown data type construction");
+        throw invalid_argument("Unknown data type construction");
     }
   }
 

--- a/include/proteus/core/data_types.hpp
+++ b/include/proteus/core/data_types.hpp
@@ -114,7 +114,7 @@ class DataType {
       case DataType::STRING:
         return sizeof(std::string);
       default:
-        throw std::invalid_argument("Unsupported type");
+        throw std::invalid_argument("Size requested of unknown data type");
     }
   }
 
@@ -152,7 +152,7 @@ class DataType {
       case DataType::STRING:
         return "STRING";
       default:
-        throw std::invalid_argument("Unsupported type");
+        throw std::invalid_argument("String requested of unknown data type");
     }
   }
 
@@ -188,7 +188,7 @@ class DataType {
       case detail::hash("UNKNOWN"):
         return DataType::UNKNOWN;
       default:
-        throw std::invalid_argument("Unsupported type construction");
+        throw std::invalid_argument("Unknown data type construction");
     }
   }
 

--- a/include/proteus/core/exceptions.hpp
+++ b/include/proteus/core/exceptions.hpp
@@ -1,0 +1,46 @@
+// Copyright 2022 Xilinx Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file
+ * @brief Defines the exception classes. Exception classes follow lower-case
+ * snake case name syntax of the standard exceptions in std
+ */
+
+#ifndef GUARD_PROTEUS_CORE_EXCEPTIONS
+#define GUARD_PROTEUS_CORE_EXCEPTIONS
+
+#include <stdexcept>
+
+namespace proteus {
+
+class bad_status : public std::runtime_error {
+  using std::runtime_error::runtime_error;
+};
+
+class file_not_found_error : public std::runtime_error {
+  using std::runtime_error::runtime_error;
+};
+
+class file_read_error : public std::runtime_error {
+  using std::runtime_error::runtime_error;
+};
+
+class external_error : public std::runtime_error {
+  using std::runtime_error::runtime_error;
+};
+
+}  // namespace proteus
+
+#endif  // GUARD_PROTEUS_CORE_EXCEPTIONS

--- a/include/proteus/core/exceptions.hpp
+++ b/include/proteus/core/exceptions.hpp
@@ -25,20 +25,24 @@
 
 namespace proteus {
 
-class bad_status : public std::runtime_error {
+class proteus_error : public std::runtime_error {
   using std::runtime_error::runtime_error;
 };
 
-class file_not_found_error : public std::runtime_error {
-  using std::runtime_error::runtime_error;
+class bad_status : public proteus_error {
+  using proteus_error::proteus_error;
 };
 
-class file_read_error : public std::runtime_error {
-  using std::runtime_error::runtime_error;
+class file_not_found_error : public proteus_error {
+  using proteus_error::proteus_error;
 };
 
-class external_error : public std::runtime_error {
-  using std::runtime_error::runtime_error;
+class file_read_error : public proteus_error {
+  using proteus_error::proteus_error;
+};
+
+class external_error : public proteus_error {
+  using proteus_error::proteus_error;
 };
 
 }  // namespace proteus

--- a/include/proteus/core/exceptions.hpp
+++ b/include/proteus/core/exceptions.hpp
@@ -25,24 +25,28 @@
 
 namespace proteus {
 
-class proteus_error : public std::runtime_error {
+class runtime_error : public std::runtime_error {
   using std::runtime_error::runtime_error;
 };
 
-class bad_status : public proteus_error {
-  using proteus_error::proteus_error;
+class bad_status : public runtime_error {
+  using runtime_error::runtime_error;
 };
 
-class file_not_found_error : public proteus_error {
-  using proteus_error::proteus_error;
+class file_not_found_error : public runtime_error {
+  using runtime_error::runtime_error;
 };
 
-class file_read_error : public proteus_error {
-  using proteus_error::proteus_error;
+class file_read_error : public runtime_error {
+  using runtime_error::runtime_error;
 };
 
-class external_error : public proteus_error {
-  using proteus_error::proteus_error;
+class external_error : public runtime_error {
+  using runtime_error::runtime_error;
+};
+
+class invalid_argument : public runtime_error {
+  using runtime_error::runtime_error;
 };
 
 }  // namespace proteus

--- a/include/proteus/proteus.hpp
+++ b/include/proteus/proteus.hpp
@@ -21,6 +21,7 @@
 #include "proteus/clients/http.hpp"
 #include "proteus/clients/native.hpp"
 #include "proteus/core/data_types.hpp"
+#include "proteus/core/exceptions.hpp"
 #include "proteus/core/predict_api.hpp"
 #include "proteus/helpers/declarations.hpp"
 // IWYU pragma: end_exports

--- a/src/proteus/batching/hard.cpp
+++ b/src/proteus/batching/hard.cpp
@@ -99,12 +99,12 @@ void HardBatcher::doRun(WorkerInfo* worker) {
         if (!worker->inputSizeValid(input_size)) {
           Manager::getInstance().workerAllocate(this->model_, input_size);
         }
-      } catch (const std::invalid_argument& e) {
+      } catch (const invalid_argument& e) {
         req->errorHandler(e);
         continue;
       }
       if (input_size == 0) {
-        auto error = std::invalid_argument("Input size is zero");
+        auto error = invalid_argument("Input size is zero");
         req->errorHandler(error);
         continue;
       }

--- a/src/proteus/batching/soft.cpp
+++ b/src/proteus/batching/soft.cpp
@@ -151,12 +151,12 @@ void SoftBatcher::doRun(WorkerInfo* worker) {
           if (!worker->inputSizeValid(input_size)) {
             Manager::getInstance().workerAllocate(this->model_, input_size);
           }
-        } catch (const std::invalid_argument& e) {
+        } catch (const invalid_argument& e) {
           req->errorHandler(e);
           continue;
         }
         if (input_size == 0) {
-          auto error = std::invalid_argument("Input size is zero");
+          auto error = invalid_argument("Input size is zero");
           req->errorHandler(error);
           continue;
         }

--- a/src/proteus/bindings/python/proteus.cpp
+++ b/src/proteus/bindings/python/proteus.cpp
@@ -23,6 +23,7 @@
 #include "proteus/bindings/python/core/data_types.hpp"
 #include "proteus/bindings/python/core/predict_api.hpp"
 #include "proteus/clients/native.hpp"
+#include "proteus/core/exceptions.hpp"
 
 namespace py = pybind11;
 
@@ -36,6 +37,8 @@ PYBIND11_MODULE(_proteus, m) {
   m.def("initialize", &initialize);
   m.def("initializeLogging", &initializeLogging);
   m.def("terminate", &terminate);
+
+  py::register_exception<proteus_error>(m, "Error");
 
   wrapRequestParameters(m);
   wrapDataType(m);

--- a/src/proteus/bindings/python/proteus.cpp
+++ b/src/proteus/bindings/python/proteus.cpp
@@ -38,7 +38,7 @@ PYBIND11_MODULE(_proteus, m) {
   m.def("initializeLogging", &initializeLogging);
   m.def("terminate", &terminate);
 
-  py::register_exception<proteus_error>(m, "Error");
+  py::register_exception<runtime_error>(m, "RuntimeError");
 
   wrapRequestParameters(m);
   wrapDataType(m);

--- a/src/proteus/clients/grpc.cpp
+++ b/src/proteus/clients/grpc.cpp
@@ -40,6 +40,7 @@
 #include "predict_api.pb.h"                  // for InferTensorContents
 #include "proteus/build_options.hpp"         // for PROTEUS_ENABLE_GRPC
 #include "proteus/core/data_types.hpp"       // for DataType, DataType::...
+#include "proteus/core/exceptions.hpp"       // for bad_status
 #include "proteus/helpers/declarations.hpp"  // for InferenceResponseOutput
 #include "proteus/servers/grpc_server.hpp"   // for start, stop
 
@@ -85,7 +86,7 @@ ServerMetadata GrpcClient::serverMetadata() {
     ServerMetadata metadata{reply.name(), reply.version(), extensions};
     return metadata;
   }
-  throw std::runtime_error(status.error_message());
+  throw bad_status(status.error_message());
 }
 
 bool GrpcClient::serverLive() {
@@ -103,7 +104,7 @@ bool GrpcClient::serverLive() {
   if (status.error_code() == ::grpc::StatusCode::UNAVAILABLE) {
     return false;
   }
-  throw std::runtime_error(status.error_message());
+  throw bad_status(status.error_message());
 }
 
 bool GrpcClient::serverReady() {
@@ -118,7 +119,7 @@ bool GrpcClient::serverReady() {
   if (status.ok()) {
     return reply.ready();
   }
-  throw std::runtime_error(status.error_message());
+  throw bad_status(status.error_message());
 }
 
 bool GrpcClient::modelReady(const std::string& model) {
@@ -135,7 +136,7 @@ bool GrpcClient::modelReady(const std::string& model) {
   if (status.ok()) {
     return reply.ready();
   }
-  throw std::invalid_argument(status.error_message());
+  throw bad_status(status.error_message());
 }
 
 std::vector<std::string> GrpcClient::modelList() {
@@ -152,7 +153,7 @@ std::vector<std::string> GrpcClient::modelList() {
     std::vector<std::string> models(mods.begin(), mods.end());
     return models;
   }
-  throw std::invalid_argument(status.error_message());
+  throw bad_status(status.error_message());
 }
 
 // refer to cppreference for std::visit
@@ -198,7 +199,7 @@ void GrpcClient::modelLoad(const std::string& model,
   Status status = stub->ModelLoad(&context, request, &reply);
 
   if (!status.ok()) {
-    throw std::runtime_error(status.error_message());
+    throw bad_status(status.error_message());
   }
 }
 
@@ -214,7 +215,7 @@ void GrpcClient::modelUnload(const std::string& model) {
   Status status = stub->ModelUnload(&context, request, &reply);
 
   if (!status.ok()) {
-    throw std::runtime_error(status.error_message());
+    throw bad_status(status.error_message());
   }
 }
 
@@ -237,7 +238,7 @@ std::string GrpcClient::workerLoad(const std::string& worker,
   if (status.ok()) {
     return reply.endpoint();
   }
-  throw std::runtime_error(status.error_message());
+  throw bad_status(status.error_message());
 }
 
 void GrpcClient::workerUnload(const std::string& worker) {
@@ -252,7 +253,7 @@ void GrpcClient::workerUnload(const std::string& worker) {
   Status status = stub->WorkerUnload(&context, request, &reply);
 
   if (!status.ok()) {
-    throw std::runtime_error(status.error_message());
+    throw bad_status(status.error_message());
   }
 }
 
@@ -522,7 +523,7 @@ InferenceResponse GrpcClient::modelInfer(const std::string& model,
   Status status = stub->ModelInfer(&context, grpc_request, &reply);
 
   if (!status.ok()) {
-    throw std::runtime_error(status.error_message());
+    throw bad_status(status.error_message());
   }
 
   InferenceResponse response;

--- a/src/proteus/clients/grpc.cpp
+++ b/src/proteus/clients/grpc.cpp
@@ -136,7 +136,7 @@ bool GrpcClient::modelReady(const std::string& model) {
   if (status.ok()) {
     return reply.ready();
   }
-  throw bad_status(status.error_message());
+  return false;
 }
 
 std::vector<std::string> GrpcClient::modelList() {

--- a/src/proteus/clients/http.cpp
+++ b/src/proteus/clients/http.cpp
@@ -174,9 +174,6 @@ bool HttpClient::modelReady(const std::string& model) {
 
   auto [result, response] = client->sendRequest(req);
   check_error(result);
-  if (response->statusCode() == drogon::k400BadRequest) {
-    throw bad_status(response->body().data());
-  }
   return response->statusCode() == drogon::k200OK;
 }
 

--- a/src/proteus/clients/http.cpp
+++ b/src/proteus/clients/http.cpp
@@ -36,6 +36,7 @@
 
 #include "proteus/build_options.hpp"          // for PROTEUS_ENABLE_HTTP
 #include "proteus/clients/http_internal.hpp"  // for mapJsonToResponse, mapP...
+#include "proteus/core/exceptions.hpp"        // for bad_status
 #include "proteus/servers/http_server.hpp"    // for stop, start
 
 namespace proteus {
@@ -104,7 +105,7 @@ void check_error(drogon::ReqResult result) {
         "Request error code: " + std::to_string(static_cast<int>(result));
   }
   if (!error_msg.empty()) {
-    throw std::runtime_error(error_msg);
+    throw bad_status(error_msg);
   }
 }
 
@@ -119,7 +120,7 @@ ServerMetadata HttpClient::serverMetadata() {
   auto [result, response] = client->sendRequest(req);
   check_error(result);
   if (response->getStatusCode() != drogon::k200OK) {
-    throw std::invalid_argument(response->getJsonError());
+    throw bad_status(response->getJsonError());
   }
   ServerMetadata metadata;
   auto json = response->getJsonObject();
@@ -174,7 +175,7 @@ bool HttpClient::modelReady(const std::string& model) {
   auto [result, response] = client->sendRequest(req);
   check_error(result);
   if (response->statusCode() == drogon::k400BadRequest) {
-    throw std::invalid_argument(response->body().data());
+    throw bad_status(response->body().data());
   }
   return response->statusCode() == drogon::k200OK;
 }
@@ -197,7 +198,7 @@ void HttpClient::modelLoad(const std::string& model,
   auto [result, response] = client->sendRequest(req);
   check_error(result);
   if (response->statusCode() != drogon::k200OK) {
-    throw std::invalid_argument(std::string(response->body()));
+    throw bad_status(std::string(response->body()));
   }
 }
 
@@ -215,8 +216,7 @@ void HttpClient::modelUnload(const std::string& model) {
   check_error(result);
   auto status = response->statusCode();
   if (status != drogon::k200OK) {
-    throw std::invalid_argument("Status: " +
-                                std::to_string(static_cast<int>(status)));
+    throw bad_status(std::string(response->body()));
   }
 }
 
@@ -238,7 +238,7 @@ std::string HttpClient::workerLoad(const std::string& model,
   auto [result, response] = client->sendRequest(req);
   check_error(result);
   if (response->statusCode() == drogon::k400BadRequest) {
-    throw std::invalid_argument(std::string(response->body()));
+    throw bad_status(std::string(response->body()));
   }
   return std::string(response->body());
 }
@@ -257,8 +257,7 @@ void HttpClient::workerUnload(const std::string& model) {
   check_error(result);
   auto status = response->statusCode();
   if (status != drogon::k200OK) {
-    throw std::invalid_argument("Status: " +
-                                std::to_string(static_cast<int>(status)));
+    throw bad_status(std::string(response->body()));
   }
 }
 
@@ -278,7 +277,7 @@ InferenceResponse HttpClient::modelInfer(const std::string& model,
   auto [result, response] = client->sendRequest(req);
   check_error(result);
   if (response->statusCode() == drogon::k400BadRequest) {
-    throw std::invalid_argument(std::string(response->body()));
+    throw bad_status(std::string(response->body()));
   }
 
   auto resp = response->jsonObject();
@@ -297,7 +296,7 @@ std::vector<std::string> HttpClient::modelList() {
   auto [result, response] = client->sendRequest(req);
   check_error(result);
   if (response->getStatusCode() != drogon::k200OK) {
-    throw std::invalid_argument(response->getJsonError());
+    throw bad_status(response->getJsonError());
   }
   auto json = response->jsonObject();
 

--- a/src/proteus/clients/http_internal.hpp
+++ b/src/proteus/clients/http_internal.hpp
@@ -103,7 +103,7 @@ class DrogonHttp : public Interface {
     size_t &batch_offset) override;
 
   size_t getInputSize() override;
-  void errorHandler(const std::invalid_argument &e) override;
+  void errorHandler(const std::exception &e) override;
 
  private:
   drogon::HttpRequestPtr req_;

--- a/src/proteus/clients/native.cpp
+++ b/src/proteus/clients/native.cpp
@@ -204,7 +204,7 @@ bool NativeClient::modelReady(const std::string& model) {
   try {
     return Manager::getInstance().workerReady(model);
   } catch (const runtime_error& e) {
-    throw bad_status(e.what());
+    return false;
   }
 }
 

--- a/src/proteus/clients/native.cpp
+++ b/src/proteus/clients/native.cpp
@@ -32,6 +32,7 @@
 #include "proteus/batching/batcher.hpp"         // for Batcher
 #include "proteus/build_options.hpp"            // for PROTEUS_ENABLE_TRACING
 #include "proteus/clients/native_internal.hpp"  // for CppNativeApi
+#include "proteus/core/exceptions.hpp"          // for bad_status
 #include "proteus/core/manager.hpp"             // for Manager
 #include "proteus/core/model_repository.hpp"    // for ModelRepository
 #include "proteus/core/worker_info.hpp"         // for WorkerInfo
@@ -197,7 +198,11 @@ void NativeClient::workerUnload(const std::string& model) {
 }
 
 bool NativeClient::modelReady(const std::string& model) {
-  return Manager::getInstance().workerReady(model);
+  try {
+    return Manager::getInstance().workerReady(model);
+  } catch (const std::invalid_argument& e) {
+    throw bad_status(e.what());
+  }
 }
 
 std::vector<std::string> NativeClient::modelList() {

--- a/src/proteus/clients/native.cpp
+++ b/src/proteus/clients/native.cpp
@@ -200,7 +200,7 @@ void NativeClient::workerUnload(const std::string& model) {
 bool NativeClient::modelReady(const std::string& model) {
   try {
     return Manager::getInstance().workerReady(model);
-  } catch (const std::invalid_argument& e) {
+  } catch (const runtime_error& e) {
     throw bad_status(e.what());
   }
 }

--- a/src/proteus/clients/native.cpp
+++ b/src/proteus/clients/native.cpp
@@ -161,6 +161,9 @@ InferenceResponseFuture NativeClient::enqueue(const std::string& workerName,
   Metrics::getInstance().incrementCounter(MetricCounterIDs::kCppNative);
 #endif
   auto* worker = proteus::Manager::getInstance().getWorker(workerName);
+  if (worker == nullptr) {
+    throw invalid_argument("Worker " + workerName + " not found");
+  }
 
 #ifdef PROTEUS_ENABLE_TRACING
   auto trace = startTrace(&(__func__[0]));

--- a/src/proteus/clients/native_internal.cpp
+++ b/src/proteus/clients/native_internal.cpp
@@ -184,7 +184,7 @@ std::shared_ptr<InferenceRequest> CppNativeApi::getRequest(
   return request;
 }
 
-void CppNativeApi::errorHandler(const std::invalid_argument &e) {
+void CppNativeApi::errorHandler(const std::exception &e) {
   PROTEUS_LOG_ERROR(this->getLogger(), e.what());
   this->getPromise()->set_value(InferenceResponse(e.what()));
 }

--- a/src/proteus/clients/native_internal.cpp
+++ b/src/proteus/clients/native_internal.cpp
@@ -88,18 +88,13 @@ class InferenceRequestBuilder<InferenceRequest> {
     auto batch_offset_backup = batch_offset;
 
     for (const auto &input : req.inputs_) {
-      try {
-        const auto &buffers = input_buffers[buffer_index];
-        for (auto &buffer : buffers) {
-          auto &offset = input_offsets[buffer_index];
+      const auto &buffers = input_buffers[buffer_index];
+      for (auto &buffer : buffers) {
+        auto &offset = input_offsets[buffer_index];
 
-          request->inputs_.push_back(
-            InputBuilder::build(input, buffer, offset));
-          const auto &last_input = request->inputs_.back();
-          offset += (last_input.getSize() * last_input.getDatatype().size());
-        }
-      } catch (const std::invalid_argument &e) {
-        throw;
+        request->inputs_.push_back(InputBuilder::build(input, buffer, offset));
+        const auto &last_input = request->inputs_.back();
+        offset += (last_input.getSize() * last_input.getDatatype().size());
       }
       batch_offset++;
       if (batch_offset == batch_size) {
@@ -115,17 +110,13 @@ class InferenceRequestBuilder<InferenceRequest> {
     batch_offset = batch_offset_backup;
     if (!req.outputs_.empty()) {
       for (const auto &output : req.outputs_) {
-        try {
-          const auto &buffers = output_buffers[buffer_index];
-          for (auto &buffer : buffers) {
-            const auto &offset = output_offsets[buffer_index];
+        const auto &buffers = output_buffers[buffer_index];
+        for (auto &buffer : buffers) {
+          const auto &offset = output_offsets[buffer_index];
 
-            request->outputs_.emplace_back(output);
-            request->outputs_.back().setData(
-              static_cast<std::byte *>(buffer->data()) + offset);
-          }
-        } catch (const std::invalid_argument &e) {
-          throw;
+          request->outputs_.emplace_back(output);
+          request->outputs_.back().setData(
+            static_cast<std::byte *>(buffer->data()) + offset);
         }
         batch_offset++;
         if (batch_offset == batch_size) {
@@ -137,17 +128,13 @@ class InferenceRequestBuilder<InferenceRequest> {
     } else {
       for (const auto &input : req.inputs_) {
         (void)input;  // suppress unused variable warning
-        try {
-          const auto &buffers = output_buffers[buffer_index];
-          for (auto &buffer : buffers) {
-            const auto &offset = output_offsets[buffer_index];
+        const auto &buffers = output_buffers[buffer_index];
+        for (auto &buffer : buffers) {
+          const auto &offset = output_offsets[buffer_index];
 
-            request->outputs_.emplace_back();
-            request->outputs_.back().setData(
-              static_cast<std::byte *>(buffer->data()) + offset);
-          }
-        } catch (const std::invalid_argument &e) {
-          throw;
+          request->outputs_.emplace_back();
+          request->outputs_.back().setData(
+            static_cast<std::byte *>(buffer->data()) + offset);
         }
         batch_offset++;
         if (batch_offset == batch_size) {

--- a/src/proteus/clients/native_internal.hpp
+++ b/src/proteus/clients/native_internal.hpp
@@ -44,7 +44,7 @@ class CppNativeApi : public Interface {
     size_t &batch_offset) override;
 
   size_t getInputSize() override;
-  void errorHandler(const std::invalid_argument &e) override;
+  void errorHandler(const std::exception &e) override;
   std::promise<proteus::InferenceResponse> *getPromise();
 
  private:

--- a/src/proteus/core/data_types.cpp
+++ b/src/proteus/core/data_types.cpp
@@ -19,10 +19,10 @@
 
 #include "proteus/core/data_types.hpp"
 
-#include <cstddef>    // for size_t
-#include <stdexcept>  // for invalid_argument
+#include <cstddef>  // for size_t
 
 #include "proteus/build_options.hpp"
+#include "proteus/core/exceptions.hpp"
 
 #ifdef PROTEUS_ENABLE_VITIS
 #include <xir/util/data_type.hpp>  // for DataType, DataType::FLOAT, DataTyp...
@@ -41,8 +41,8 @@ DataType mapXirToType(xir::DataType type) {
     if (width == DataType("FP64").size()) {
       return DataType::FP64;
     }
-    throw std::invalid_argument("Unsupported XIR float width: " +
-                                std::to_string(width));
+    throw invalid_argument("Unsupported XIR float width: " +
+                           std::to_string(width));
   }
   if (data_type == xir::DataType::INT || data_type == xir::DataType::XINT) {
     if (width == DataType("INT8").size()) {
@@ -57,8 +57,8 @@ DataType mapXirToType(xir::DataType type) {
     if (width == DataType("INT64").size()) {
       return DataType::INT64;
     }
-    throw std::invalid_argument("Unsupported XIR int width: " +
-                                std::to_string(width));
+    throw invalid_argument("Unsupported XIR int width: " +
+                           std::to_string(width));
   }
   if (data_type == xir::DataType::UINT || data_type == xir::DataType::XUINT) {
     if (width == DataType("UINT8").size()) {
@@ -73,11 +73,10 @@ DataType mapXirToType(xir::DataType type) {
     if (width == DataType("UINT64").size()) {
       return DataType::UINT64;
     }
-    throw std::invalid_argument("Unsupported XIR uint width: " +
-                                std::to_string(width));
+    throw invalid_argument("Unsupported XIR uint width: " +
+                           std::to_string(width));
   }
-  throw std::invalid_argument("Unsupported XIR type: " +
-                              std::to_string(data_type));
+  throw invalid_argument("Unsupported XIR type: " + std::to_string(data_type));
 }
 
 xir::DataType mapTypeToXir(DataType type) {
@@ -102,7 +101,7 @@ xir::DataType mapTypeToXir(DataType type) {
       retval.type = xir::DataType::FLOAT;
       break;
     default:
-      throw std::invalid_argument("Unsupported type conversion to XIR");
+      throw invalid_argument("Unsupported type conversion to XIR");
   }
   retval.bit_width = bit_width;
   return retval;

--- a/src/proteus/core/interface.hpp
+++ b/src/proteus/core/interface.hpp
@@ -101,7 +101,7 @@ class Interface {
    *
    * @param e the raised exception
    */
-  virtual void errorHandler(const std::invalid_argument &e) = 0;
+  virtual void errorHandler(const std::exception &e) = 0;
 
  protected:
   InterfaceType type_;

--- a/src/proteus/core/manager.cpp
+++ b/src/proteus/core/manager.cpp
@@ -76,7 +76,7 @@ void Manager::unloadWorker(const std::string& key) {
 WorkerInfo* Manager::getWorker(const std::string& key) {
   auto* worker_info = this->endpoints_.get(key);
   if (worker_info == nullptr) {
-    throw std::invalid_argument("worker " + key + " not found");
+    throw invalid_argument("worker " + key + " not found");
   }
   return worker_info;
 }

--- a/src/proteus/core/manager.hpp
+++ b/src/proteus/core/manager.hpp
@@ -108,7 +108,7 @@ class Manager {
 
   /**
    * @brief Get the WorkerInfo object associated with the given key. If the
-   * worker does not exist, throws an exception.
+   * worker does not exist, returns nullptr
    *
    * @param key name of the worker
    * @return WorkerInfo*

--- a/src/proteus/core/model_repository.cpp
+++ b/src/proteus/core/model_repository.cpp
@@ -23,6 +23,7 @@
 #include <fstream>
 
 #include "model_config.pb.h"
+#include "proteus/core/exceptions.hpp"
 #include "proteus/core/manager.hpp"
 #include "proteus/core/predict_api.hpp"
 #include "proteus/core/worker_info.hpp"
@@ -102,14 +103,14 @@ void ModelRepository::ModelRepositoryImpl::modelLoad(
   int fileDescriptor = open(config_path.c_str(), O_RDONLY);
 
   if (fileDescriptor < 0) {
-    throw std::runtime_error("Config file could not be opened");
+    throw file_not_found_error("Config file could not be opened");
   }
 
   google::protobuf::io::FileInputStream fileInput(fileDescriptor);
   fileInput.SetCloseOnDelete(true);
 
   if (!google::protobuf::TextFormat::Parse(&fileInput, &config)) {
-    throw std::runtime_error("Config file could not be parsed");
+    throw file_read_error("Config file could not be parsed");
   }
 
   const auto& inputs = config.inputs();
@@ -137,7 +138,7 @@ void ModelRepository::ModelRepositoryImpl::modelLoad(
   } else if (config.platform() == "vitis_xmodel") {
     parameters->put("worker", "xmodel");
   } else {
-    throw std::runtime_error("Unknown platform");
+    throw std::invalid_argument("Unknown platform");
   }
 
   mapProtoToParameters2(config.parameters(), parameters);

--- a/src/proteus/core/model_repository.cpp
+++ b/src/proteus/core/model_repository.cpp
@@ -138,7 +138,7 @@ void ModelRepository::ModelRepositoryImpl::modelLoad(
   } else if (config.platform() == "vitis_xmodel") {
     parameters->put("worker", "xmodel");
   } else {
-    throw std::invalid_argument("Unknown platform");
+    throw invalid_argument("Unknown platform");
   }
 
   mapProtoToParameters2(config.parameters(), parameters);
@@ -160,7 +160,7 @@ void UpdateListener::handleFileAction([[maybe_unused]] efsw::WatchID watchid,
       try {
         ModelRepository::modelLoad(model, &params);
         Manager::getInstance().loadWorker(model, params);
-      } catch (const std::runtime_error& e) {
+      } catch (const runtime_error&) {
         PROTEUS_LOG_INFO(logger, "Error loading " + model.string());
       }
     } else if (action == efsw::Actions::Delete) {

--- a/src/proteus/core/worker_info.cpp
+++ b/src/proteus/core/worker_info.cpp
@@ -32,6 +32,7 @@
 
 #include "proteus/batching/batcher.hpp"  // for Batcher, BatcherStatus, Batc...
 #include "proteus/build_options.hpp"     // for PROTEUS_ENABLE_LOGGING
+#include "proteus/core/exceptions.hpp"   // for file_not_found_error
 #include "proteus/core/interface.hpp"    // IWYU pragma: keep
 #include "proteus/core/predict_api.hpp"  // for RequestParameters
 #include "proteus/workers/worker.hpp"    // for Worker, WorkerStatus, Worker...
@@ -57,7 +58,7 @@ void* findFunc(const std::string& func, const std::string& soPath) {
   void* handle = dlopen(soPath.c_str(), RTLD_LOCAL | RTLD_LAZY);
   if (handle == nullptr) {
     const char* error_str = dlerror();
-    throw std::invalid_argument(error_str);
+    throw file_not_found_error(error_str);
   }
 
   /* find the address of function  */

--- a/src/proteus/core/worker_info.cpp
+++ b/src/proteus/core/worker_info.cpp
@@ -48,7 +48,7 @@ namespace proteus {
  */
 void* findFunc(const std::string& func, const std::string& soPath) {
   if (func.empty() || soPath.empty()) {
-    throw std::invalid_argument("Function or .so path empty");
+    throw invalid_argument("Function or .so path empty");
   }
 
   // reset errors
@@ -65,7 +65,7 @@ void* findFunc(const std::string& func, const std::string& soPath) {
   void* fptr = dlsym(handle, func.c_str());
   if (fptr == nullptr) {
     const char* error_str = dlerror();
-    throw std::invalid_argument(error_str);
+    throw invalid_argument(error_str);
   }
   return fptr;
 }
@@ -256,7 +256,7 @@ bool WorkerInfo::inputSizeValid(size_t size) const {
   if (size <= this->getMaxBufferNum()) {
     return false;
   }
-  throw std::invalid_argument("Too many input tensors for this model");
+  throw invalid_argument("Too many input tensors for this model");
 }
 
 void WorkerInfo::allocate(size_t request_size) {

--- a/src/proteus/helpers/CMakeLists.txt
+++ b/src/proteus/helpers/CMakeLists.txt
@@ -21,7 +21,7 @@ list(APPEND TARGETS
 
 foreach(target ${TARGETS})
   add_library(${target} STATIC ${target}.cpp)
-  target_include_directories(${target} PRIVATE ${PROJECT_SOURCE_DIR}/src)
+  target_include_directories(${target} PRIVATE ${PROTEUS_INCLUDE_DIRS})
   enable_ipo_on_target(${target})
 endforeach()
 

--- a/src/proteus/helpers/exec.cpp
+++ b/src/proteus/helpers/exec.cpp
@@ -14,11 +14,12 @@
 
 #include "proteus/helpers/exec.hpp"
 
-#include <array>      // for array
-#include <cstdio>     // for pclose, fgets, popen, FILE
-#include <memory>     // for unique_ptr
-#include <stdexcept>  // for runtime_error
-#include <string>     // for string
+#include <array>   // for array
+#include <cstdio>  // for pclose, fgets, popen, FILE
+#include <memory>  // for unique_ptr
+#include <string>  // for string
+
+#include "proteus/core/exceptions.hpp"
 
 namespace proteus {
 
@@ -27,9 +28,9 @@ std::string exec(const char* cmd) {
   std::array<char, 128> buffer;  // NOLINT
   std::string result;
   // NOLINTNEXTLINE(cert-env33-c)
-  std::unique_ptr<FILE, decltype(&pclose)> pipe(popen(cmd, "r"), pclose);
+  std::unique_ptr<FILE, decltype(&pclose)> pipe(popen(cmd, "r"), &pclose);
   if (!pipe) {
-    throw std::runtime_error("popen() failed!");
+    throw external_error("popen() failed!");
   }
   while (fgets(buffer.data(), buffer.size(), pipe.get()) != nullptr) {
     result += buffer.data();

--- a/src/proteus/main.cpp
+++ b/src/proteus/main.cpp
@@ -119,7 +119,7 @@ int main(int argc, char* argv[]) {
         auto model = path.path().filename();
         try {
           client.modelLoad(model, nullptr);
-        } catch (const std::runtime_error& e) {
+        } catch (const proteus::runtime_error&) {
           PROTEUS_LOG_INFO(logger, "Error loading " + model.string());
         }
       }

--- a/src/proteus/servers/grpc_server.cpp
+++ b/src/proteus/servers/grpc_server.cpp
@@ -464,7 +464,7 @@ void grpcUnaryCallback(CallDataModelInfer* calldata,
   }
   try {
     mapResponsetoProto(response, calldata->getReply());
-  } catch (const std::invalid_argument& e) {
+  } catch (const invalid_argument& e) {
     calldata->finish(::grpc::Status(StatusCode::UNKNOWN, e.what()));
     return;
   }
@@ -505,7 +505,7 @@ class GrpcApiUnary : public Interface {
         std::bind(grpcUnaryCallback, this->calldata_, std::placeholders::_1);
       request->setCallback(std::move(callback));
       return request;
-    } catch (const std::invalid_argument& e) {
+    } catch (const invalid_argument& e) {
       PROTEUS_LOG_INFO(logger, e.what());
       errorHandler(e);
       return nullptr;
@@ -516,7 +516,7 @@ class GrpcApiUnary : public Interface {
     return calldata_->getRequest().inputs_size();
   }
 
-  void errorHandler(const std::invalid_argument& e) override {
+  void errorHandler(const std::exception& e) override {
     PROTEUS_LOG_INFO(this->getLogger(), e.what());
     calldata_->finish(::grpc::Status(StatusCode::NOT_FOUND, e.what()));
   }
@@ -542,7 +542,7 @@ CALLDATA_IMPL(ModelReady, Unary) {
   try {
     reply_.set_ready(Manager::getInstance().workerReady(model));
     finish();
-  } catch (const std::invalid_argument& e) {
+  } catch (const invalid_argument& e) {
     reply_.set_ready(false);
     finish(::grpc::Status(StatusCode::NOT_FOUND, e.what()));
   }
@@ -651,7 +651,7 @@ void CallDataModelInfer::handleRequest() {
   WorkerInfo* worker = nullptr;
   try {
     worker = Manager::getInstance().getWorker(model);
-  } catch (const std::invalid_argument& e) {
+  } catch (const invalid_argument& e) {
     PROTEUS_LOG_INFO(logger_, e.what());
     finish(
       ::grpc::Status(StatusCode::NOT_FOUND, "Worker " + model + " not found"));

--- a/src/proteus/servers/grpc_server.cpp
+++ b/src/proteus/servers/grpc_server.cpp
@@ -649,10 +649,9 @@ void CallDataModelInfer::handleRequest() {
 #endif
 
   WorkerInfo* worker = nullptr;
-  try {
-    worker = Manager::getInstance().getWorker(model);
-  } catch (const invalid_argument& e) {
-    PROTEUS_LOG_INFO(logger_, e.what());
+  worker = Manager::getInstance().getWorker(model);
+  if (worker == nullptr) {
+    PROTEUS_LOG_INFO(logger_, "Worker " + model + " not found");
     finish(
       ::grpc::Status(StatusCode::NOT_FOUND, "Worker " + model + " not found"));
     return;

--- a/src/proteus/servers/grpc_server.cpp
+++ b/src/proteus/servers/grpc_server.cpp
@@ -381,18 +381,13 @@ class InferenceRequestBuilder<CallDataModelInfer*> {
     auto batch_offset_backup = batch_offset;
 
     for (const auto& input : grpc_request.inputs()) {
-      try {
-        auto buffers = input_buffers[buffer_index];
-        for (auto& buffer : buffers) {
-          auto& offset = input_offsets[buffer_index];
+      auto buffers = input_buffers[buffer_index];
+      for (auto& buffer : buffers) {
+        auto& offset = input_offsets[buffer_index];
 
-          request->inputs_.push_back(
-            InputBuilder::build(input, buffer, offset));
-          const auto& last_input = request->inputs_.back();
-          offset += (last_input.getSize() * last_input.getDatatype().size());
-        }
-      } catch (const std::invalid_argument& e) {
-        throw;
+        request->inputs_.push_back(InputBuilder::build(input, buffer, offset));
+        const auto& last_input = request->inputs_.back();
+        offset += (last_input.getSize() * last_input.getDatatype().size());
       }
       batch_offset++;
       if (batch_offset == batch_size) {
@@ -411,17 +406,13 @@ class InferenceRequestBuilder<CallDataModelInfer*> {
       for (const auto& output : grpc_request.outputs()) {
         // TODO(varunsh): we're ignoring incoming output data
         (void)output;
-        try {
-          auto buffers = output_buffers[buffer_index];
-          for (auto& buffer : buffers) {
-            auto& offset = output_offsets[buffer_index];
+        auto buffers = output_buffers[buffer_index];
+        for (auto& buffer : buffers) {
+          auto& offset = output_offsets[buffer_index];
 
-            request->outputs_.emplace_back();
-            request->outputs_.back().setData(
-              static_cast<std::byte*>(buffer->data()) + offset);
-          }
-        } catch (const std::invalid_argument& e) {
-          throw;
+          request->outputs_.emplace_back();
+          request->outputs_.back().setData(
+            static_cast<std::byte*>(buffer->data()) + offset);
         }
         batch_offset++;
         if (batch_offset == batch_size) {
@@ -433,18 +424,14 @@ class InferenceRequestBuilder<CallDataModelInfer*> {
     } else {
       for (const auto& input : grpc_request.inputs()) {
         (void)input;  // suppress unused variable warning
-        try {
-          auto buffers = output_buffers[buffer_index];
-          for (size_t j = 0; j < buffers.size(); j++) {
-            auto& buffer = buffers[j];
-            const auto& offset = output_offsets[buffer_index];
+        auto buffers = output_buffers[buffer_index];
+        for (size_t j = 0; j < buffers.size(); j++) {
+          auto& buffer = buffers[j];
+          const auto& offset = output_offsets[buffer_index];
 
-            request->outputs_.emplace_back();
-            request->outputs_.back().setData(
-              static_cast<std::byte*>(buffer->data()) + offset);
-          }
-        } catch (const std::invalid_argument& e) {
-          throw;
+          request->outputs_.emplace_back();
+          request->outputs_.back().setData(
+            static_cast<std::byte*>(buffer->data()) + offset);
         }
         batch_offset++;
         if (batch_offset == batch_size) {

--- a/src/proteus/servers/http_server.cpp
+++ b/src/proteus/servers/http_server.cpp
@@ -183,8 +183,8 @@ void v2::ProteusHttpServer::getModelMetadata(
   try {
     auto metadata = Manager::getInstance().getWorkerMetadata(model);
     ret = ModelMetadataToJson(metadata);
-  } catch (const invalid_argument &e) {
-    ret["error"] = "Model " + model + " not found.";
+  } catch (const runtime_error &e) {
+    ret["error"] = e.what();
     error = true;
   }
 
@@ -248,10 +248,9 @@ void v2::ProteusHttpServer::inferModel(
 #endif
 
   WorkerInfo *worker = nullptr;
-  try {
-    worker = Manager::getInstance().getWorker(model);
-  } catch (const invalid_argument &e) {
-    PROTEUS_LOG_INFO(logger_, e.what());
+  worker = Manager::getInstance().getWorker(model);
+  if (worker == nullptr) {
+    PROTEUS_LOG_INFO(logger_, "Worker " + model + " not found");
     auto resp = errorHttpResponse("Worker " + model + " not found",
                                   HttpStatusCode::k400BadRequest);
 #ifdef PROTEUS_ENABLE_TRACING

--- a/src/proteus/servers/http_server.cpp
+++ b/src/proteus/servers/http_server.cpp
@@ -138,7 +138,7 @@ void v2::ProteusHttpServer::getModelReady(
     if (!Manager::getInstance().workerReady(model)) {
       resp->setStatusCode(HttpStatusCode::k503ServiceUnavailable);
     }
-  } catch (const std::invalid_argument &e) {
+  } catch (const invalid_argument &e) {
     resp->setStatusCode(HttpStatusCode::k400BadRequest);
     resp->setBody(e.what());
   }
@@ -183,7 +183,7 @@ void v2::ProteusHttpServer::getModelMetadata(
   try {
     auto metadata = Manager::getInstance().getWorkerMetadata(model);
     ret = ModelMetadataToJson(metadata);
-  } catch (const std::invalid_argument &e) {
+  } catch (const invalid_argument &e) {
     ret["error"] = "Model " + model + " not found.";
     error = true;
   }
@@ -250,7 +250,7 @@ void v2::ProteusHttpServer::inferModel(
   WorkerInfo *worker = nullptr;
   try {
     worker = Manager::getInstance().getWorker(model);
-  } catch (const std::invalid_argument &e) {
+  } catch (const invalid_argument &e) {
     PROTEUS_LOG_INFO(logger_, e.what());
     auto resp = errorHttpResponse("Worker " + model + " not found",
                                   HttpStatusCode::k400BadRequest);
@@ -265,7 +265,7 @@ void v2::ProteusHttpServer::inferModel(
   std::unique_ptr<DrogonHttp> request;
   try {
     request = std::make_unique<DrogonHttp>(req, std::move(callback));
-  } catch (const std::invalid_argument &e) {
+  } catch (const invalid_argument &e) {
     PROTEUS_LOG_INFO(logger_, e.what());
     auto resp = errorHttpResponse(e.what(), HttpStatusCode::k400BadRequest);
 #ifdef PROTEUS_ENABLE_TRACING

--- a/src/proteus/servers/websocket_server.cpp
+++ b/src/proteus/servers/websocket_server.cpp
@@ -86,7 +86,7 @@ void WebsocketServer::handleNewMessage(const WebSocketConnectionPtr &conn,
   WorkerInfo *worker = nullptr;
   try {
     worker = Manager::getInstance().getWorker(model);
-  } catch (const std::invalid_argument &e) {
+  } catch (const invalid_argument &e) {
     PROTEUS_LOG_INFO(logger_, e.what());
     conn->shutdown(drogon::CloseCode::kInvalidMessage,
                    "Model " + model + " not loaded");
@@ -124,7 +124,7 @@ DrogonWs::DrogonWs(const drogon::WebSocketConnectionPtr &conn,
 size_t DrogonWs::getInputSize() {
   auto inputs = this->json_->get("inputs", Json::arrayValue);
   if (!inputs.isArray()) {
-    throw std::invalid_argument("'inputs' is not an array");
+    throw invalid_argument("'inputs' is not an array");
   }
   return inputs.size();
 }
@@ -153,7 +153,7 @@ std::shared_ptr<InferenceRequest> DrogonWs::getRequest(
       };
     request->setCallback(std::move(callback));
     return request;
-  } catch (const std::invalid_argument &e) {
+  } catch (const invalid_argument &e) {
     PROTEUS_LOG_INFO(logger, e.what());
     this->conn_->shutdown(drogon::CloseCode::kUnexpectedCondition,
                           "Failed to create request");
@@ -161,7 +161,7 @@ std::shared_ptr<InferenceRequest> DrogonWs::getRequest(
   }
 }
 
-void DrogonWs::errorHandler(const std::invalid_argument &e) {
+void DrogonWs::errorHandler(const std::exception &e) {
   PROTEUS_LOG_INFO(this->getLogger(), e.what());
   this->conn_->shutdown(drogon::CloseCode::kUnexpectedCondition, e.what());
 }

--- a/src/proteus/servers/websocket_server.cpp
+++ b/src/proteus/servers/websocket_server.cpp
@@ -83,13 +83,11 @@ void WebsocketServer::handleNewMessage(const WebSocketConnectionPtr &conn,
 
   auto request = std::make_unique<DrogonWs>(conn, std::move(json));
 
-  WorkerInfo *worker = nullptr;
-  try {
-    worker = Manager::getInstance().getWorker(model);
-  } catch (const invalid_argument &e) {
-    PROTEUS_LOG_INFO(logger_, e.what());
+  auto *worker = Manager::getInstance().getWorker(model);
+  if (worker == nullptr) {
+    PROTEUS_LOG_INFO(logger_, "Worker " + model + " not found");
     conn->shutdown(drogon::CloseCode::kInvalidMessage,
-                   "Model " + model + " not loaded");
+                   "Worker " + model + " not found");
     return;
   }
   auto *batcher = worker->getBatcher();

--- a/src/proteus/servers/websocket_server.hpp
+++ b/src/proteus/servers/websocket_server.hpp
@@ -58,7 +58,7 @@ class DrogonWs : public Interface {
     size_t &batch_offset) override;
 
   size_t getInputSize() override;
-  void errorHandler(const std::invalid_argument &e) override;
+  void errorHandler(const std::exception &e) override;
 
  private:
   void setJson();

--- a/src/proteus/workers/aks.cpp
+++ b/src/proteus/workers/aks.cpp
@@ -39,6 +39,7 @@
 #include "proteus/buffers/vector_buffer.hpp"  // for VectorBuffer
 #include "proteus/build_options.hpp"          // for PROTEUS_ENABLE_TRACING
 #include "proteus/core/data_types.hpp"        // for DataType, DataType::FP32
+#include "proteus/core/exceptions.hpp"        // for external_error
 #include "proteus/core/predict_api.hpp"       // for InferenceResponse, Infe...
 #include "proteus/helpers/declarations.hpp"   // for BufferPtrs, InferenceRe...
 #include "proteus/helpers/parse_env.hpp"      // for autoExpandEnvironmentVa...
@@ -123,7 +124,7 @@ void Aks::doAcquire(RequestParameters* parameters) {
   std::string graph_name = "graph_adder";
   this->graph_ = sysMan_->getGraph(graph_name);
   if (this->graph_ == nullptr) {
-    throw std::runtime_error("AKS graph " + graph_name + " not found");
+    throw external_error("AKS graph " + graph_name + " not found");
   }
 
   this->metadata_.addInputTensor("input", DataType::FP32,

--- a/tests/api/test_model_infer.py
+++ b/tests/api/test_model_infer.py
@@ -55,5 +55,5 @@ class TestModelInfer:
         try:
             while self.rest_client.modelReady(endpoint):
                 time.sleep(1)
-        except proteus.Error:
+        except proteus.RuntimeError:
             pass

--- a/tests/api/test_model_infer.py
+++ b/tests/api/test_model_infer.py
@@ -55,5 +55,5 @@ class TestModelInfer:
         try:
             while self.rest_client.modelReady(endpoint):
                 time.sleep(1)
-        except ValueError:
+        except RuntimeError:
             pass

--- a/tests/api/test_model_infer.py
+++ b/tests/api/test_model_infer.py
@@ -55,5 +55,5 @@ class TestModelInfer:
         try:
             while self.rest_client.modelReady(endpoint):
                 time.sleep(1)
-        except RuntimeError:
+        except proteus.Error:
             pass

--- a/tests/api/test_model_load.py
+++ b/tests/api/test_model_load.py
@@ -64,10 +64,10 @@ class TestLoad:
         try:
             while self.rest_client.modelReady(endpoint_0):
                 time.sleep(1)
-        except ValueError:
+        except RuntimeError:
             pass
         try:
             while self.rest_client.modelReady(endpoint_1):
                 time.sleep(1)
-        except ValueError:
+        except RuntimeError:
             pass

--- a/tests/api/test_model_load.py
+++ b/tests/api/test_model_load.py
@@ -64,10 +64,10 @@ class TestLoad:
         try:
             while self.rest_client.modelReady(endpoint_0):
                 time.sleep(1)
-        except RuntimeError:
+        except proteus.Error:
             pass
         try:
             while self.rest_client.modelReady(endpoint_1):
                 time.sleep(1)
-        except RuntimeError:
+        except proteus.Error:
             pass

--- a/tests/api/test_model_load.py
+++ b/tests/api/test_model_load.py
@@ -61,13 +61,7 @@ class TestLoad:
             endpoint_1
         )  # this unloads the second echo-0 worker
 
-        try:
-            while self.rest_client.modelReady(endpoint_0):
-                time.sleep(1)
-        except proteus.RuntimeError:
-            pass
-        try:
-            while self.rest_client.modelReady(endpoint_1):
-                time.sleep(1)
-        except proteus.RuntimeError:
-            pass
+        while self.rest_client.modelReady(endpoint_0):
+            time.sleep(1)
+        while self.rest_client.modelReady(endpoint_1):
+            time.sleep(1)

--- a/tests/api/test_model_load.py
+++ b/tests/api/test_model_load.py
@@ -64,10 +64,10 @@ class TestLoad:
         try:
             while self.rest_client.modelReady(endpoint_0):
                 time.sleep(1)
-        except proteus.Error:
+        except proteus.RuntimeError:
             pass
         try:
             while self.rest_client.modelReady(endpoint_1):
                 time.sleep(1)
-        except proteus.Error:
+        except proteus.RuntimeError:
             pass

--- a/tests/api/test_model_ready.cpp
+++ b/tests/api/test_model_ready.cpp
@@ -34,15 +34,12 @@ void test(proteus::Client* client) {
   auto models_0 = client->modelList();
   EXPECT_TRUE(models_0.empty());
 
-  // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto, hicpp-avoid-goto)
-  EXPECT_THROW_CHECK({ client->modelReady(worker); },
-                     { EXPECT_STREQ("Worker echo not found", e.what()); },
-                     proteus::bad_status);
+  EXPECT_FALSE(client->modelReady(worker));
 
   const auto endpoint = client->workerLoad(worker, nullptr);
   EXPECT_EQ(endpoint, worker);
 
-  while (!isReady(client, endpoint)) {
+  while (!client->modelReady(endpoint)) {
     std::this_thread::sleep_for(std::chrono::milliseconds(10));
   }
 

--- a/tests/api/test_model_ready.cpp
+++ b/tests/api/test_model_ready.cpp
@@ -23,7 +23,7 @@
 bool isReady(proteus::Client* client, const std::string& endpoint) {
   try {
     return client->modelReady(endpoint);
-  } catch (const std::invalid_argument& e) {
+  } catch (const proteus::bad_status&) {
     return false;
   }
 }
@@ -37,7 +37,7 @@ void test(proteus::Client* client) {
   // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto, hicpp-avoid-goto)
   EXPECT_THROW_CHECK({ client->modelReady(worker); },
                      { EXPECT_STREQ("worker echo not found", e.what()); },
-                     std::invalid_argument);
+                     proteus::bad_status);
 
   const auto endpoint = client->workerLoad(worker, nullptr);
   EXPECT_EQ(endpoint, worker);

--- a/tests/api/test_model_ready.cpp
+++ b/tests/api/test_model_ready.cpp
@@ -36,7 +36,7 @@ void test(proteus::Client* client) {
 
   // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto, hicpp-avoid-goto)
   EXPECT_THROW_CHECK({ client->modelReady(worker); },
-                     { EXPECT_STREQ("worker echo not found", e.what()); },
+                     { EXPECT_STREQ("Worker echo not found", e.what()); },
                      proteus::bad_status);
 
   const auto endpoint = client->workerLoad(worker, nullptr);

--- a/tests/api/test_model_ready.py
+++ b/tests/api/test_model_ready.py
@@ -15,6 +15,8 @@
 import pytest
 import time
 
+import proteus
+
 
 @pytest.mark.usefixtures("server")
 class TestModelReady:
@@ -25,7 +27,7 @@ class TestModelReady:
     def is_ready(self, worker):
         try:
             return self.rest_client.modelReady(worker)
-        except RuntimeError:
+        except proteus.Error:
             return False
 
     def test_model_ready(self):
@@ -38,7 +40,7 @@ class TestModelReady:
         models = self.rest_client.modelList()
         assert len(models) == 0
 
-        with pytest.raises(RuntimeError) as e_info:
+        with pytest.raises(proteus.Error) as e_info:
             self.rest_client.modelReady(worker)
             assert str(e_info.value) == f"worker {worker} not found"
 

--- a/tests/api/test_model_ready.py
+++ b/tests/api/test_model_ready.py
@@ -42,7 +42,7 @@ class TestModelReady:
 
         with pytest.raises(proteus.RuntimeError) as e_info:
             self.rest_client.modelReady(worker)
-            assert str(e_info.value) == f"worker {worker} not found"
+            assert str(e_info.value) == f"Worker {worker} not found"
 
         endpoint_0 = self.rest_client.workerLoad(worker)
         assert endpoint_0 == "echo"

--- a/tests/api/test_model_ready.py
+++ b/tests/api/test_model_ready.py
@@ -25,7 +25,7 @@ class TestModelReady:
     def is_ready(self, worker):
         try:
             return self.rest_client.modelReady(worker)
-        except ValueError:
+        except RuntimeError:
             return False
 
     def test_model_ready(self):
@@ -38,7 +38,7 @@ class TestModelReady:
         models = self.rest_client.modelList()
         assert len(models) == 0
 
-        with pytest.raises(ValueError) as e_info:
+        with pytest.raises(RuntimeError) as e_info:
             self.rest_client.modelReady(worker)
             assert str(e_info.value) == f"worker {worker} not found"
 

--- a/tests/api/test_model_ready.py
+++ b/tests/api/test_model_ready.py
@@ -24,12 +24,6 @@ class TestModelReady:
     Base class for modelReady tests using the Python bindings
     """
 
-    def is_ready(self, worker):
-        try:
-            return self.rest_client.modelReady(worker)
-        except proteus.RuntimeError:
-            return False
-
     def test_model_ready(self):
         """
         Test that modelReady correctly throws errors and
@@ -40,13 +34,11 @@ class TestModelReady:
         models = self.rest_client.modelList()
         assert len(models) == 0
 
-        with pytest.raises(proteus.RuntimeError) as e_info:
-            self.rest_client.modelReady(worker)
-            assert str(e_info.value) == f"Worker {worker} not found"
+        assert not self.rest_client.modelReady(worker)
 
         endpoint_0 = self.rest_client.workerLoad(worker)
         assert endpoint_0 == "echo"
-        while not self.is_ready(worker):
+        while not self.rest_client.modelReady(worker):
             time.sleep(1)
 
         models = self.rest_client.modelList()
@@ -54,7 +46,7 @@ class TestModelReady:
 
         self.rest_client.modelUnload(worker)
 
-        while self.is_ready(worker):
+        while self.rest_client.modelReady(worker):
             time.sleep(1)
 
         models = self.rest_client.modelList()

--- a/tests/api/test_model_ready.py
+++ b/tests/api/test_model_ready.py
@@ -27,7 +27,7 @@ class TestModelReady:
     def is_ready(self, worker):
         try:
             return self.rest_client.modelReady(worker)
-        except proteus.Error:
+        except proteus.RuntimeError:
             return False
 
     def test_model_ready(self):
@@ -40,7 +40,7 @@ class TestModelReady:
         models = self.rest_client.modelList()
         assert len(models) == 0
 
-        with pytest.raises(proteus.Error) as e_info:
+        with pytest.raises(proteus.RuntimeError) as e_info:
             self.rest_client.modelReady(worker)
             assert str(e_info.value) == f"worker {worker} not found"
 

--- a/tests/api/test_worker_load.py
+++ b/tests/api/test_worker_load.py
@@ -64,10 +64,10 @@ class TestLoad:
         try:
             while self.rest_client.modelReady(endpoint_0):
                 time.sleep(1)
-        except ValueError:
+        except RuntimeError:
             pass
         try:
             while self.rest_client.modelReady(endpoint_1):
                 time.sleep(1)
-        except ValueError:
+        except RuntimeError:
             pass

--- a/tests/api/test_worker_load.py
+++ b/tests/api/test_worker_load.py
@@ -64,10 +64,10 @@ class TestLoad:
         try:
             while self.rest_client.modelReady(endpoint_0):
                 time.sleep(1)
-        except RuntimeError:
+        except proteus.Error:
             pass
         try:
             while self.rest_client.modelReady(endpoint_1):
                 time.sleep(1)
-        except RuntimeError:
+        except proteus.Error:
             pass

--- a/tests/api/test_worker_load.py
+++ b/tests/api/test_worker_load.py
@@ -61,13 +61,7 @@ class TestLoad:
             endpoint_1
         )  # this unloads the second echo-0 worker
 
-        try:
-            while self.rest_client.modelReady(endpoint_0):
-                time.sleep(1)
-        except proteus.RuntimeError:
-            pass
-        try:
-            while self.rest_client.modelReady(endpoint_1):
-                time.sleep(1)
-        except proteus.RuntimeError:
-            pass
+        while self.rest_client.modelReady(endpoint_0):
+            time.sleep(1)
+        while self.rest_client.modelReady(endpoint_1):
+            time.sleep(1)

--- a/tests/api/test_worker_load.py
+++ b/tests/api/test_worker_load.py
@@ -64,10 +64,10 @@ class TestLoad:
         try:
             while self.rest_client.modelReady(endpoint_0):
                 time.sleep(1)
-        except proteus.Error:
+        except proteus.RuntimeError:
             pass
         try:
             while self.rest_client.modelReady(endpoint_1):
                 time.sleep(1)
-        except proteus.Error:
+        except proteus.RuntimeError:
             pass

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -253,7 +253,7 @@ def load(request, rest_client, model_fixture, parameters_fixture: dict, server):
     try:
         while not rest_client.modelReady(response):
             time.sleep(1)
-    except proteus.Error:
+    except proteus.RuntimeError:
         pass
 
     yield  # perform testing

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -253,7 +253,7 @@ def load(request, rest_client, model_fixture, parameters_fixture: dict, server):
     try:
         while not rest_client.modelReady(response):
             time.sleep(1)
-    except RuntimeError:
+    except proteus.Error:
         pass
 
     yield  # perform testing

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -50,7 +50,7 @@ def pytest_sessionstart(session):
     proteus_command = [str(run_path)]
     http_port = session.config.getoption("--http_port")
     proteus_command.extend(["--http-port", str(http_port)])
-    proteus_command.extend(["--model-repository", root_path/"external/repository"])
+    proteus_command.extend(["--model-repository", root_path / "external/repository"])
 
     http_server_addr = "http://" + get_http_addr(session.config)
     addr = socket.gethostbyname(session.config.getoption("hostname"))
@@ -253,7 +253,7 @@ def load(request, rest_client, model_fixture, parameters_fixture: dict, server):
     try:
         while not rest_client.modelReady(response):
             time.sleep(1)
-    except ValueError:
+    except RuntimeError:
         pass
 
     yield  # perform testing

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -250,11 +250,8 @@ def load(request, rest_client, model_fixture, parameters_fixture: dict, server):
     response = rest_client.workerLoad(model_fixture, parameters)
     request.cls.model = response
 
-    try:
-        while not rest_client.modelReady(response):
-            time.sleep(1)
-    except proteus.RuntimeError:
-        pass
+    while not rest_client.modelReady(response):
+        time.sleep(1)
 
     yield  # perform testing
 

--- a/tests/src/proteus/batching/batcher.cpp
+++ b/tests/src/proteus/batching/batcher.cpp
@@ -61,7 +61,7 @@ class FakeInterface : public Interface {
     size_t &batch_offset) override;
 
   size_t getInputSize() override;
-  void errorHandler(const std::invalid_argument &e) override;
+  void errorHandler(const std::exception &e) override;
   std::promise<proteus::InferenceResponse> *getPromise();
 
  private:
@@ -100,7 +100,7 @@ std::shared_ptr<InferenceRequest> FakeInterface::getRequest(
   return request;
 }
 
-void FakeInterface::errorHandler(const std::invalid_argument &e) {
+void FakeInterface::errorHandler(const std::exception &e) {
   PROTEUS_LOG_ERROR(this->getLogger(), e.what());
   (void)e;  // suppress unused variable warning
 }

--- a/tests/src/proteus/core/manager.cpp
+++ b/tests/src/proteus/core/manager.cpp
@@ -47,7 +47,7 @@ void Manager::unloadWorker(const std::string& key) {
 WorkerInfo* Manager::getWorker(const std::string& key) {
   auto* worker_info = this->endpoints_.get(key);
   if (worker_info == nullptr) {
-    throw std::invalid_argument("worker " + key + " not found");
+    throw invalid_argument("worker " + key + " not found");
   }
   return worker_info;
 }

--- a/tests/src/proteus/core/manager.cpp
+++ b/tests/src/proteus/core/manager.cpp
@@ -45,11 +45,7 @@ void Manager::unloadWorker(const std::string& key) {
 }
 
 WorkerInfo* Manager::getWorker(const std::string& key) {
-  auto* worker_info = this->endpoints_.get(key);
-  if (worker_info == nullptr) {
-    throw invalid_argument("worker " + key + " not found");
-  }
-  return worker_info;
+  return this->endpoints_.get(key);
 }
 
 bool Manager::workerReady(const std::string& key) {
@@ -59,6 +55,9 @@ bool Manager::workerReady(const std::string& key) {
 
 ModelMetadata Manager::getWorkerMetadata(const std::string& key) {
   auto* worker = this->getWorker(key);
+  if (worker == nullptr) {
+    throw invalid_argument("Worker " + key + " not found");
+  }
   auto* foo = worker->workers_.begin()->second;
   return foo->getMetadata();
 }

--- a/tests/workers/test_echo.cpp
+++ b/tests/workers/test_echo.cpp
@@ -163,7 +163,7 @@ TEST_P(EchoParamFixture, EchoGrpc) {
     try {
       auto response = client.modelInfer("echo", request);
       FAIL() << "No runtime error thrown";
-    } catch (const std::runtime_error& e) {
+    } catch (const runtime_error& e) {
       EXPECT_STREQ(e.what(), "Too many input tensors for this model");
     }
   } else {
@@ -177,7 +177,7 @@ TEST_P(EchoParamFixture, EchoGrpc) {
 #endif
 
 // add_id, add_input_parameters, add_request_parameters, add_outputs, multiplier
-std::tuple<bool, bool, bool, bool, int> configs[] = {
+const std::tuple<bool, bool, bool, bool, int> configs[] = {
   {true, true, true, true, 1},      {true, true, false, true, 1},
   {true, false, false, true, 1},    {false, false, false, true, 1},
   {false, false, false, false, 1},  {false, false, false, false, 10},

--- a/tests/workers/test_echo.py
+++ b/tests/workers/test_echo.py
@@ -235,7 +235,7 @@ class TestEcho:
 
         try:
             response = self.rest_client.modelInfer(self.model, request)
-        except proteus.Error as e:
+        except proteus.RuntimeError as e:
             assert str(e) == '{"error":"Too many input tensors for this model"}'
         else:
             pytest.fail("Exception not raised")

--- a/tests/workers/test_echo.py
+++ b/tests/workers/test_echo.py
@@ -235,7 +235,7 @@ class TestEcho:
 
         try:
             response = self.rest_client.modelInfer(self.model, request)
-        except ValueError as e:
+        except RuntimeError as e:
             assert str(e) == '{"error":"Too many input tensors for this model"}'
         else:
             pytest.fail("Exception not raised")

--- a/tests/workers/test_echo.py
+++ b/tests/workers/test_echo.py
@@ -235,7 +235,7 @@ class TestEcho:
 
         try:
             response = self.rest_client.modelInfer(self.model, request)
-        except RuntimeError as e:
+        except proteus.Error as e:
             assert str(e) == '{"error":"Too many input tensors for this model"}'
         else:
             pytest.fail("Exception not raised")


### PR DESCRIPTION
# Summary of Changes

*  Add custom exceptions deriving from `std::runtime_error`
*  Change `modelReady` so it doesn't throw an exception on failure

Closes #30

# Motivation

Exceptions in the inference server were a mix of standard C++ exceptions but they were inconsistently used. By using custom exceptions, each exception gets a descriptive name and we can use them more consistently throughout. We can also move towards ensuring that any exceptions thrown into user code will be one of ours so they're easy to catch.

# Implementation

New exceptions classes are added in a header file. They follow the naming syntax of existing C++ exceptions. In the Python bindings, the base class

Previously, `workerReady`, the internal version of `modelReady` would through an exception if a worker wasn't found. As this is a non-exceptional scenario, this case no longer throws an exception. Instead, it simply returns false. This change allows removing a number of try-catch blocks from the code.
