### PR TITLE
39 pt+zendnn test hangs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -34,7 +34,9 @@ Added
 - 'modelList' endpoint to the API (:commit:`7477b7d`)
 - Parse JSON data as string in HTTP body (:commit:`694800e`)
 - Directory monitoring for model loading (:commit:`6459797`)
+- 'ModelMetadata' endpoint to the API (:commit:`22b9d1a`)
 - MIGraphX backend (:pr:`34`)
+- Pre-commit for style verification(:commit:`048bdd7`)
 
 Changed
 ^^^^^^^
@@ -55,6 +57,7 @@ Fixed
 - Calculate offset values correctly during batching (:commit:`8c7534b`)
 - Get correct library dependencies for production container (:commit:`14ed4ef`)
 - Correctly throw an exception if a worker gets an error during initialization (:pr:`29`)
+- Detect errors in HTTP client during loading (:commit:`99ffc33`)
 
 
 :github:`0.1.0 <Xilinx/inference-server/releases/tag/v0.1.0>` - 2022-02-08

--- a/proteus
+++ b/proteus
@@ -880,6 +880,22 @@ class Get:
                                 os.path.join(modelpath, modelname),
                                 os.path.join(location, modelname),
                             )
+                            if modelname.endswith("pth"):
+                                subprocess.check_call(
+                                    [
+                                        sys.executable,
+                                        "-m",
+                                        "pip",
+                                        "install",
+                                        "-r",
+                                        "tools/zendnn/requirements.txt",
+                                    ]
+                                )
+                                import tools.zendnn.convert_to_torchscript as converter
+
+                                converter_args = argparse.Namespace
+                                converter_args.graph = os.path.join(location, modelname)
+                                converter.main(converter_args)
                     else:
                         shutil.copy2(filepath, str(location / filename))
                         os.remove(filepath)

--- a/src/proteus/clients/http.cpp
+++ b/src/proteus/clients/http.cpp
@@ -100,7 +100,7 @@ ServerMetadata HttpClient::serverMetadata() {
 
   auto [result, response] = client->sendRequest(req);
   check_error(result);
-  if (response->getStatusCode() != drogon::k200OK) {
+  if (response->statusCode() != drogon::k200OK) {
     throw bad_status(response->getJsonError());
   }
   ServerMetadata metadata;
@@ -229,7 +229,7 @@ std::string HttpClient::workerLoad(const std::string& model,
 
   auto [result, response] = client->sendRequest(req);
   check_error(result);
-  if (response->statusCode() == drogon::k400BadRequest) {
+  if (response->statusCode() != drogon::k200OK) {
     throw bad_status(std::string(response->body()));
   }
   return std::string(response->body());
@@ -268,7 +268,7 @@ InferenceResponse HttpClient::modelInfer(const std::string& model,
 
   auto [result, response] = client->sendRequest(req);
   check_error(result);
-  if (response->statusCode() == drogon::k400BadRequest) {
+  if (response->statusCode() != drogon::k200OK) {
     throw bad_status(std::string(response->body()));
   }
 
@@ -287,7 +287,7 @@ std::vector<std::string> HttpClient::modelList() {
 
   auto [result, response] = client->sendRequest(req);
   check_error(result);
-  if (response->getStatusCode() != drogon::k200OK) {
+  if (response->statusCode() != drogon::k200OK) {
     throw bad_status(response->getJsonError());
   }
   auto json = response->jsonObject();

--- a/tools/zendnn/convert_to_torchscript.py
+++ b/tools/zendnn/convert_to_torchscript.py
@@ -37,12 +37,18 @@ def main(args):
         )
     try:
         import torch
-        from resnet50 import resnet50
     except ModuleNotFoundError:
         raise ModuleNotFoundError(
-            "PyTorch not installed, plese install"
+            "PyTorch not installed, please install"
             " PyTorch/refer the docs to use this script. "
         )
+
+    # the way this script is called determines which import will succeed, so try
+    # both
+    try:
+        from resnet50 import resnet50
+    except ImportError:
+        from .resnet50 import resnet50
 
     # Prepare filename to save the model
     # <model>.pth-><model>.pt


### PR DESCRIPTION
# Summary of Changes

*  Fix the hanging PT+ZenDNN test
*  Auto convert .pth models used in tests to .pt
*  More robust error handling in servers

Closes #39

# Motivation

Tests and examples should be able to run by default and without arguments especially for CI.

# Implementation

The problem with the hanging test was an error in the HTTP client library which was incorrectly detecting errors during ``workerLoad``. Then, the test would hang on while waiting for ``modelReady`` which would never succeed since the loading had failed. The solution was to detect errors correctly so the test fails.

The error handling in the PT+ZenDNN worker is improved where the worker throws exceptions on irrecoverable errors rather than just logging them. There's also some clean up to rename some variables that were shadowing others and style.

Per the ZenDNN setup instructions, users are required to convert PyTorch Eager models to TorchScript models. This step is now run by default on models fetched with ``proteus get`` so that the right files exist for tests and examples.

In addition to catching internal exceptions, the servers (gRPC and HTTP) now also catch all ``std::exception`` to prevent an uncaught exception from bringing down the server. These are explicitly added to the gRPC server while the HTTP server has them implicitly through Drogon.
