### PR TITLE
Update image normalization vectors for migraphx worker tests

### DIFF
--- a/examples/python/hello_migraphx.py
+++ b/examples/python/hello_migraphx.py
@@ -71,10 +71,11 @@ def preprocess(img_data):
 
     Args:
         img_data (np.array): 3 dimensions [channels, rows, cols] with value range 0-255
+        the vectors are for RGB images, so images read with OpenCV must have channels 
+        converted before calling.
     """
-    # todo: are these vectors based on RGB images or BGR?  Results seem good
-    mean_vec = np.array([0.485, 0.456, 0.406])
-    stddev_vec = np.array([0.229, 0.224, 0.225])
+    mean_vec = np.array([0.406, 0.456, 0.485])
+    stddev_vec = np.array([0.225, 0.224, 0.229])
     norm_img_data = np.zeros(img_data.shape).astype("float32")
     for i in range(img_data.shape[0]):
         norm_img_data[i, :, :] = (img_data[i, :, :] / 255 - mean_vec[i]) / stddev_vec[i]
@@ -156,7 +157,7 @@ def parse_args():
         required=False,
         default=os.path.join(
             root, "tests/assets/dog-3619020_640.jpg"
-        ),  # a girl in a sweatshirt
+        ),  # a dog
         help="An image to try inference on.  Use git-lfs to pull image assets",
     )
 

--- a/examples/python/migraph_resnet.py
+++ b/examples/python/migraph_resnet.py
@@ -77,10 +77,11 @@ def preprocess(img_data):
 
     Args:
         img_data (np.array): 3 dimensions [channels, rows, cols] with value range 0-255
+        the vectors are for RGB images, so images read with OpenCV must have channels 
+        converted before calling.
     """
-    # todo: are these vectors based on RGB images or BGR?  Results seem good
-    mean_vec = np.array([0.485, 0.456, 0.406])
-    stddev_vec = np.array([0.229, 0.224, 0.225])
+    mean_vec = np.array([0.406, 0.456, 0.485])
+    stddev_vec = np.array([0.225, 0.224, 0.229])
     norm_img_data = np.zeros(img_data.shape).astype("float32")
     for i in range(img_data.shape[0]):
         norm_img_data[i, :, :] = (img_data[i, :, :] / 255 - mean_vec[i]) / stddev_vec[i]

--- a/tests/workers/test_migraphx.py
+++ b/tests/workers/test_migraphx.py
@@ -57,12 +57,13 @@ def preprocess(img_data):
 
     Args:
         img_data (np.array): array in 3 dimensions [channels, rows, cols] with value range 0-255
-
+        The vectors are for RGB images, so images read with OpenCV must have channels 
+        converted before calling.
     Returns:
         Response: np.array
     """
-    mean_vec = np.array([0.485, 0.456, 0.406])
-    stddev_vec = np.array([0.229, 0.224, 0.225])
+    mean_vec = np.array([0.406, 0.456, 0.485])
+    stddev_vec = np.array([0.225, 0.224, 0.229])
     norm_img_data = np.zeros(img_data.shape).astype("float32")
     for i in range(img_data.shape[0]):
         norm_img_data[i, :, :] = (img_data[i, :, :] / 255 - mean_vec[i]) / stddev_vec[i]
@@ -133,9 +134,7 @@ class TestMigraphx:
             str(root_path / "tests/assets/dog-3619020_640.jpg"),
             str(root_path / "tests/assets/bicycle-384566_640.jpg"),
         ]
-
-        gold_responses = [[259, 261, 157, 260, 154], [444, 671, 880, 518, 870]]
-
+        gold_responses = [[259, 261, 157, 260, 154], [671, 444, 880, 518, 870]]
         assert len(image_paths) == len(gold_responses)
         image_num = len(image_paths)
 


### PR DESCRIPTION
# Summary of Changes

* Since inputs to normalization were changed from BGR color channel format to RGB, vectors are reordered to match.  Also updates test gold values.

# Motivation
When I made the last PR to convert images from BGR to RGB I wasn't sure which format the corresponding normalization vectors were written for.  More investigation shows they needed to be reversed.  This restores the label for the bicycle test image to a better result (although the larger Imagenet validation set gives inconclusive results; this change doesn't seem to make much difference in overall accuracy).

