### PR TITLE
migraphx example script fix

### DIFF
--- a/examples/python/hello_migraphx.py
+++ b/examples/python/hello_migraphx.py
@@ -223,6 +223,7 @@ def main(args):
             break
 
     print("This model's shape of input image is ", shape)
+    # If only 3 dimensions were found, assume the 0'th dimension was not parsed and insert a 1.
     if len(shape) == 3:
         shape.insert(0, 1)
     if len(shape) != 4:

--- a/examples/python/migraph_resnet.py
+++ b/examples/python/migraph_resnet.py
@@ -211,8 +211,8 @@ def main(args):
 
     print("This model's shape of input image is ", shape)
     # If only 3 dimensions were found, assume the 0'th dimension was not parsed and insert a 1.
-    # if len(shape) == 3:
-    #     shape.insert(0, 1)
+    if len(shape) == 3:
+        shape.insert(0, 1)
     if len(shape) != 4:
         print(
             "Unable to read the image dimensions from ",

--- a/examples/python/migraph_resnet.py
+++ b/examples/python/migraph_resnet.py
@@ -210,6 +210,9 @@ def main(args):
             break
 
     print("This model's shape of input image is ", shape)
+    # If only 3 dimensions were found, assume the 0'th dimension was not parsed and insert a 1.
+    # if len(shape) == 3:
+    #     shape.insert(0, 1)
     if len(shape) != 4:
         print(
             "Unable to read the image dimensions from ",

--- a/examples/python/migraph_resnet.py
+++ b/examples/python/migraph_resnet.py
@@ -321,10 +321,6 @@ def main(args):
                 )
                 print("     ----------------------------------------")
 
-    # # for debug: redisplay the processed images
-    display_img = images[5]
-    display_img = display_img.transpose(1, 2, 0)
-
     print("Done")
 
     # If this line is commented out, worker persists with doRun thread active, and the entire script


### PR DESCRIPTION
#Two-line change adds a check that allows ONNX files with 3 instead of 4 dimensions.  This is a change that was already present in the other Migraphx example script.  This allows the script to be used for tests with different Resnet models.  (Some Resnet versions apparently have a variable value for the 0'th dimension, which isn't found by the script.)  