### PR TITLE
Fix ptzendnn bug with resnet classes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,10 @@
 repos:
   # Python hooks
+  - repo: https://github.com/pycqa/isort
+    rev: 5.10.1
+    hooks:
+      - id: isort
+        name: isort (python)
   - repo: https://github.com/psf/black
     rev: 22.3.0
     hooks:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -47,6 +47,7 @@ Changed
 - Loading workers is now case-insensitive (:commit:`14ed4ef` and :commit:`90a51ae`)
 - Build AKS from source (:commit:`e04890f`)
 - Use consistent custom exceptions (:pr:`30`)
+- Update Docker build commands to opt-in to all backends (:pr:`43`)
 
 Fixed
 ^^^^^

--- a/examples/cpp/pt_zendnn_client.cpp
+++ b/examples/cpp/pt_zendnn_client.cpp
@@ -212,6 +212,7 @@ struct Option {
 
   int batch_size = 640;
   int input_size = 224;
+  int output_classes = 1000;
   int warmup_step = 5;
   int steps = 10;
   int topK = 5;
@@ -247,6 +248,7 @@ int main() {
   parameters.put("max_buffer_num", options.batch_size);
   parameters.put("model", options.graph);
   parameters.put("input_size", options.input_size);
+  parameters.put("output_classes", options.output_classes);
   auto workerName = client.workerLoad("PtZendnn", &parameters);
 
   float time_tmp = 0.f;

--- a/examples/python/pt_zendnn.py
+++ b/examples/python/pt_zendnn.py
@@ -18,9 +18,9 @@ import sys
 import time
 
 import numpy as np
+from utils.utils import postprocess, preprocess_pt
 
 import proteus
-from utils.utils import preprocess_pt, postprocess
 
 
 def main(args):
@@ -88,6 +88,7 @@ def main(args):
     parameters = proteus.RequestParameters()
     parameters.put("model", args.graph)
     parameters.put("input_size", input_size)
+    parameters.put("output_classes", 1000)
     worker_name = client.workerLoad("PtZendnn", parameters)
 
     ready = False
@@ -98,7 +99,7 @@ def main(args):
     # If with real data, do preprocessing, otherwise create dummy data
     if real_data:
         # For tests with single images
-        images = [preprocess_pt(args.image_location, input_size)]
+        images = []
         images.append(preprocess_pt(args.image_location, input_size))
         request = proteus.ImageInferenceRequest(images)
         response = client.modelInfer(worker_name, request)
@@ -110,8 +111,8 @@ def main(args):
 
         # Print top1 and top5 classess
         print("Image: {}".format(args.image_location))
-        print("Top 1 Class: {}".format(classes[idx_1[0]]))
-        print("Top 5 classes: {}".format(", ".join(classes[idx_5])))
+        print("Top 1 Class: {}".format(classes[idx_1[0]][0]))
+        print("Top 5 classes: {}".format(", ".join(classes[tuple(idx_5)])))
 
     else:
         # For functionality check with multiple images

--- a/src/proteus/workers/pt_zendnn.cpp
+++ b/src/proteus/workers/pt_zendnn.cpp
@@ -38,9 +38,7 @@
 #include "proteus/observation/metrics.hpp"    // for Metrics
 #include "proteus/observation/tracing.hpp"    // for startFollowSpan, SpanPtr
 #include "proteus/workers/worker.hpp"         // for Worker
-#include "torch/csrc/jit/passes/freeze_module.h"
-#include "torch/csrc/jit/passes/frozen_graph_optimizations.h"
-#include "torch/script.h"
+#include "torch/script.h"                     // for PyTorch
 
 namespace fs = std::filesystem;
 
@@ -109,7 +107,7 @@ void PtZendnn::doInit(RequestParameters* parameters) {
   this->batch_size_ = batch_size;
 
   // Image properties
-  unsigned kTotalClasses = 1001;
+  unsigned kTotalClasses = 1000;
   unsigned kImageWidth = 224;
   unsigned kImageHeight = 224;
   unsigned kImageChannels = 3;
@@ -151,7 +149,7 @@ void PtZendnn::doAcquire(RequestParameters* parameters) {
 #endif
 
   if (!parameters->has("model")) {
-    throw invalid_argument("No model not provided in load-time parameters");
+    throw invalid_argument("Model not provided in load-time parameters");
   }
   fs::path path = parameters->get<std::string>("model");
   if (!path.has_extension()) {
@@ -175,9 +173,6 @@ void PtZendnn::doAcquire(RequestParameters* parameters) {
 
   // Some online optimizations for the model
   torch_module.eval();
-  torch_module = torch::jit::freeze_module(torch_module);
-  auto graph = torch_module.get_method("forward").graph();
-  OptimizeFrozenGraph(graph, true);
   try {
     torch_module = torch::jit::optimize_for_inference(torch_module);
   } catch (const std::exception& e) {

--- a/tests/workers/test_ptzendnn.py
+++ b/tests/workers/test_ptzendnn.py
@@ -15,14 +15,14 @@
 import os
 import sys
 
-import pytest
 import numpy as np
+import pytest
+from helper import root_path, run_benchmark
+
 import proteus
 
-from helper import run_benchmark, root_path
-
 sys.path.insert(0, os.path.join(root_path, "examples/python"))
-from utils.utils import preprocess_pt, postprocess
+from utils.utils import postprocess, preprocess_pt
 
 
 @pytest.fixture(scope="class")
@@ -35,6 +35,7 @@ def parameters_fixture():
     return {
         "model": str(root_path / "external/pytorch_models/resnet50_pretrained.pt"),
         "input_size": 224,
+        "output_classes": 1000,
     }
 
 


### PR DESCRIPTION
# Summary of Changes

*  Fixes classification bug with ResNet50 and ptzendnn
*  Throw exceptions in tfzendnn on error

Closes #46

# Motivation

Fixes #46 and by throwing exceptions in the tfzendnn worker, the client can be made aware of why it failed to load.

# Implementation

The number of output classes are added to the ptzendnn worker's load-time parameters.