### PR TITLE
Fix batching batch size bug

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -21,6 +21,7 @@ external/aks/libs
 external/artifacts
 external/repository
 private/
+src/proteus/bindings/python/dist
 
 # files
 **/callgrind.out.*

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ external/aks/*
 external/overlaybins
 docs/_*/
 tests/shell/test_helper
+src/proteus/bindings/python/dist
 
 # files
 callgrind.out.*

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,6 +5,7 @@ repos:
     hooks:
       - id: isort
         name: isort (python)
+        args: ["--profile", "black"]
   - repo: https://github.com/psf/black
     rev: 22.3.0
     hooks:

--- a/examples/cpp/custom_processing.cpp
+++ b/examples/cpp/custom_processing.cpp
@@ -250,7 +250,7 @@ int main() {
   std::string root = root_env;
 
   // +user variables: update as needed!
-  const auto request_num = 8;
+  const auto request_num = 4;
   const auto* path_to_xmodel =
     "${PROTEUS_ROOT}/external/artifacts/u200_u250/resnet_v1_50_tf/"
     "resnet_v1_50_tf.xmodel";

--- a/examples/cpp/pt_zendnn_client.cpp
+++ b/examples/cpp/pt_zendnn_client.cpp
@@ -249,6 +249,7 @@ int main() {
   parameters.put("model", options.graph);
   parameters.put("input_size", options.input_size);
   parameters.put("output_classes", options.output_classes);
+  parameters.put("batch_size", options.batch_size);
   auto workerName = client.workerLoad("PtZendnn", &parameters);
 
   float time_tmp = 0.f;

--- a/examples/cpp/tf_zendnn_client.cpp
+++ b/examples/cpp/tf_zendnn_client.cpp
@@ -264,6 +264,7 @@ int main() {
   parameters.put("input_size", options.input_size);
   parameters.put("inter_op", options.inter_op);
   parameters.put("intra_op", options.intra_op);
+  parameters.put("batch_size", options.batch_size);
   auto workerName = client.workerLoad("TfZendnn", &parameters);
 
   float time_tmp = 0.f;

--- a/examples/python/pt_zendnn.py
+++ b/examples/python/pt_zendnn.py
@@ -89,6 +89,7 @@ def main(args):
     parameters.put("model", args.graph)
     parameters.put("input_size", input_size)
     parameters.put("output_classes", 1000)
+    parameters.put("batch_size", batch_size)
     worker_name = client.workerLoad("PtZendnn", parameters)
 
     ready = False

--- a/examples/python/tf_zendnn.py
+++ b/examples/python/tf_zendnn.py
@@ -18,10 +18,10 @@ import sys
 import time
 
 import numpy as np
+from utils.utils import postprocess, preprocess
 
 import proteus
 import proteus.clients
-from utils.utils import preprocess, postprocess
 
 
 def main(args):
@@ -96,6 +96,7 @@ def main(args):
     parameters.put("output_classes", output_classes)
     parameters.put("inter_op", args.inter_op)
     parameters.put("intra_op", args.intra_op)
+    parameters.put("batch_size", batch_size)
     worker_name = client.workerLoad("TfZendnn", parameters)
 
     ready = False

--- a/src/proteus/batching/soft.cpp
+++ b/src/proteus/batching/soft.cpp
@@ -24,6 +24,7 @@
 #include <cstddef>    // for size_t
 #include <cstdint>    // for int32_t
 #include <memory>     // for unique_ptr, allocator
+#include <queue>      // for queue
 #include <ratio>      // for ratio
 #include <stdexcept>  // for invalid_argument
 #include <string>     // for operator+, char_traits
@@ -57,9 +58,6 @@ void SoftBatcher::doRun(WorkerInfo* worker) {
   const auto& logger = this->getLogger();
 #endif
 
-  std::vector<InterfacePtr> reqs;
-  reqs.resize(this->batch_size_);
-  size_t count = 0;
   bool run = true;
 
   auto kTimeout = duration_cast<milliseconds>(kDefaultTimeout);
@@ -67,6 +65,8 @@ void SoftBatcher::doRun(WorkerInfo* worker) {
     kTimeout = duration_cast<milliseconds>(
       milliseconds(this->parameters_.get<int32_t>("timeout")));
   }
+
+  std::queue<InterfacePtr> backup;
 
   while (run) {
     auto batch = std::make_unique<Batch>();
@@ -81,142 +81,149 @@ void SoftBatcher::doRun(WorkerInfo* worker) {
     size_t batch_size = 0;
 
 #ifdef PROTEUS_ENABLE_METRICS
-    Metrics::getInstance().setGauge(MetricGaugeIDs::kQueuesBatcherInput,
-                                    input_queue_->size_approx());
-    Metrics::getInstance().setGauge(MetricGaugeIDs::kQueuesBatcherOutput,
-                                    output_queue_->size_approx());
+    Metrics::getInstance().setGauge(
+      MetricGaugeIDs::kQueuesBatcherInput,
+      static_cast<double>(input_queue_->size_approx()));
+    Metrics::getInstance().setGauge(
+      MetricGaugeIDs::kQueuesBatcherOutput,
+      static_cast<double>(output_queue_->size_approx()));
 #endif
 
     bool first_request = true;
     auto start_time = std::chrono::high_resolution_clock::now();
 
     do {
-      if (first_request) {
-        // wait for the first request
-        count = 1;
-        this->input_queue_->wait_dequeue(reqs.at(0));
-        // TODO(varunsh): there's a bug where if batch size is 4, and we get
-        // requests of size 4, we pull in 4 of them. In the loop below, more
-        // buffers aren't correctly grabbed so we end up with only using one
-        // buffer for input/output instead of 4
-        // count = this->input_queue_->wait_dequeue_bulk(
-        //   std::make_move_iterator(reqs.begin()), this->batch_size_);
-        start_time = std::chrono::high_resolution_clock::now();
-        PROTEUS_LOG_DEBUG(logger,
-                          "Got request of a new batch for " + this->model_);
+      InterfacePtr req;
+      if (!backup.empty()) {
+        req = std::move(backup.front());
+        backup.pop();
       } else {
-        count = 1;
-        auto remaining_time =
-          kTimeout - (std::chrono::high_resolution_clock::now() - start_time);
-        auto duration = std::max(remaining_time, std::chrono::nanoseconds(0));
-        bool valid = this->input_queue_->wait_dequeue_timed(reqs[0], duration);
-        if (!valid) {
-          break;
+        if (first_request) {
+          // wait for the first request
+          this->input_queue_->wait_dequeue(req);
+          start_time = std::chrono::high_resolution_clock::now();
+          PROTEUS_LOG_DEBUG(logger,
+                            "Got request of a new batch for " + this->model_);
+        } else {
+          auto remaining_time =
+            kTimeout - (std::chrono::high_resolution_clock::now() - start_time);
+          auto duration = std::max(remaining_time, std::chrono::nanoseconds(0));
+          bool valid = this->input_queue_->wait_dequeue_timed(req, duration);
+          if (!valid) {
+            break;
+          }
         }
       }
 
-      for (size_t j = 0; j < count; j++) {
-        InterfacePtr req;
-        req = std::move(reqs[j]);
+      if (req == nullptr) {
+        run = false;
+        break;
+      }
 
-        if (req == nullptr) {
-          run = false;
-          break;
+      size_t input_size = 0;
+      try {
+        input_size = req->getInputSize();
+        if (!worker->inputSizeValid(input_size)) {
+          Manager::getInstance().workerAllocate(this->model_, input_size);
         }
+      } catch (const invalid_argument& e) {
+        req->errorHandler(e);
+        continue;
+      }
+      if (input_size == 0) {
+        auto error = invalid_argument("Input size is zero");
+        req->errorHandler(error);
+        continue;
+      }
 
-        std::vector<BufferRawPtrs> input_buffers;
-        input_buffers.emplace_back();
-        for (const auto& buffer : input_buffer) {
-          input_buffers.back().push_back(buffer.get());
-        }
-        std::vector<BufferRawPtrs> output_buffers;
-        output_buffers.emplace_back();
-        for (const auto& buffer : output_buffer) {
-          output_buffers.back().push_back(buffer.get());
-        }
+      if (input_size > batch_size_) {
+        auto error = invalid_argument("Input size is larger than batch size");
+        req->errorHandler(error);
+        continue;
+      }
+
+      if (batch_size + input_size > batch_size_) {
+        backup.push(std::move(req));
+        break;
+      }
+
+      std::vector<BufferRawPtrs> input_buffers;
+      input_buffers.emplace_back();
+      for (const auto& buffer : input_buffer) {
+        input_buffers.back().push_back(buffer.get());
+      }
+      std::vector<BufferRawPtrs> output_buffers;
+      output_buffers.emplace_back();
+      for (const auto& buffer : output_buffer) {
+        output_buffers.back().push_back(buffer.get());
+      }
 
 #ifdef PROTEUS_ENABLE_TRACING
-        auto trace = req->getTrace();
-        trace->startSpan("soft_batcher");
+      auto trace = req->getTrace();
+      trace->startSpan("soft_batcher");
 #endif
 
 #ifdef PROTEUS_ENABLE_METRICS
-        Metrics::getInstance().incrementCounter(
-          MetricCounterIDs::kPipelineIngressBatcher);
+      Metrics::getInstance().incrementCounter(
+        MetricCounterIDs::kPipelineIngressBatcher);
 #endif
 
-        size_t input_size = 0;
-        try {
-          input_size = req->getInputSize();
-          if (!worker->inputSizeValid(input_size)) {
-            Manager::getInstance().workerAllocate(this->model_, input_size);
+      auto buffers_needed =
+        ((input_size + batch_size - 1) / this->batch_size_) + 1;
+      if (buffers_needed > 1) {
+        for (size_t i = 1; i < buffers_needed; i++) {
+          batch->input_buffers->push_back(std::move(input_buffer));
+          batch->output_buffers->push_back(std::move(output_buffer));
+          input_buffer = worker->getInputBuffer();
+          input_buffers.emplace_back();
+          for (const auto& buffer : input_buffer) {
+            input_buffers.back().push_back(buffer.get());
           }
-        } catch (const invalid_argument& e) {
-          req->errorHandler(e);
-          continue;
+          output_buffer = worker->getOutputBuffer();
+          output_buffers.emplace_back();
+          for (const auto& buffer : output_buffer) {
+            output_buffers.back().push_back(buffer.get());
+          }
+          input_offset.push_back(0);
+          output_offset.push_back(0);
         }
-        if (input_size == 0) {
-          auto error = invalid_argument("Input size is zero");
-          req->errorHandler(error);
-          continue;
+      }
+
+      auto old_input_offset = input_offset;
+      auto old_output_offset = output_offset;
+      size_t buffer_index = 0;
+      auto new_req = req->getRequest(buffer_index, input_buffers, input_offset,
+                                     output_buffers, output_offset,
+                                     this->batch_size_, batch_size);
+      if (new_req == nullptr) {
+        PROTEUS_LOG_DEBUG(logger, "Making request for " + this->model_ +
+                                    " failed. Reverting buffers.");
+        for (size_t i = 1; i < buffers_needed; i++) {
+          worker->putInputBuffer(std::move(input_buffer));
+          input_buffer = std::move(batch->input_buffers->back());
+          batch->input_buffers->pop_back();
+
+          worker->putOutputBuffer(std::move(output_buffer));
+          output_buffer = std::move(batch->output_buffers->back());
+          batch->output_buffers->pop_back();
+
+          input_buffers.pop_back();
+          output_buffers.pop_back();
         }
-        auto buffers_needed =
-          ((input_size + batch_size - 1) / this->batch_size_) + 1;
-        if (buffers_needed > 1) {
-          for (size_t i = 1; i < buffers_needed; i++) {
-            batch->input_buffers->push_back(std::move(input_buffer));
-            batch->output_buffers->push_back(std::move(output_buffer));
-            input_buffer = worker->getInputBuffer();
-            input_buffers.emplace_back();
-            for (const auto& buffer : input_buffer) {
-              input_buffers.back().push_back(buffer.get());
-            }
-            output_buffer = worker->getOutputBuffer();
-            output_buffers.emplace_back();
-            for (const auto& buffer : output_buffer) {
-              output_buffers.back().push_back(buffer.get());
-            }
-            input_offset.push_back(0);
-            output_offset.push_back(0);
-          }
+        input_offset = old_input_offset;
+        output_offset = old_output_offset;
+      } else {
+        batch->requests->push_back(new_req);
+        if (first_request) {
+          first_request = false;
         }
-
-        auto old_input_offset = input_offset;
-        auto old_output_offset = output_offset;
-        size_t buffer_index = 0;
-        auto new_req = req->getRequest(
-          buffer_index, input_buffers, input_offset, output_buffers,
-          output_offset, this->batch_size_, batch_size);
-        if (new_req == nullptr) {
-          PROTEUS_LOG_DEBUG(logger, "Making request for " + this->model_ +
-                                      " failed. Reverting buffers.");
-          for (size_t i = 1; i < buffers_needed; i++) {
-            worker->putInputBuffer(std::move(input_buffer));
-            input_buffer = std::move(batch->input_buffers->back());
-            batch->input_buffers->pop_back();
-
-            worker->putOutputBuffer(std::move(output_buffer));
-            output_buffer = std::move(batch->output_buffers->back());
-            batch->output_buffers->pop_back();
-
-            input_buffers.pop_back();
-            output_buffers.pop_back();
-          }
-          input_offset = old_input_offset;
-          output_offset = old_output_offset;
-        } else {
-          batch->requests->push_back(new_req);
-          if (first_request) {
-            first_request = false;
-          }
 #ifdef PROTEUS_ENABLE_TRACING
-          trace->endSpan();
-          batch->traces.emplace_back(std::move(trace));
+        trace->endSpan();
+        batch->traces.emplace_back(std::move(trace));
 #endif
 #ifdef PROTEUS_ENABLE_METRICS
-          batch->start_times.emplace_back(req->get_time());
+        batch->start_times.emplace_back(req->get_time());
 #endif
-        }
       }
     } while (batch_size % this->batch_size_ != 0 && run);
 

--- a/tests/unit/batching/test_soft_batching.cpp
+++ b/tests/unit/batching/test_soft_batching.cpp
@@ -15,7 +15,9 @@
 #include <cstddef>   // for size_t
 #include <cstdint>   // for uint8_t, uint64_t
 #include <memory>    // for allocator, make_unique
+#include <numeric>   // for accumulate
 #include <optional>  // for optional
+#include <queue>     // for queue
 #include <utility>   // for pair, move
 #include <vector>    // for vector
 
@@ -32,12 +34,32 @@
 
 namespace proteus {
 
-constexpr auto kTimeoutMs = 1000;  // timeout in ms
-constexpr auto kTimeoutUs =
-  kTimeoutMs * 1000 * 1.5;  // timeout in us with buffer
+// timeout in ms for the batcher
+constexpr auto kTimeoutMs = 1000;
+// timeout in us with a safety factor of 10 to read from the batcher
+constexpr auto kTimeoutUs = kTimeoutMs * 1000 * 10;
 
-class UnitSoftBatcherFixture
-  : public testing::TestWithParam<std::pair<int, int>> {
+struct BatchConfig {
+  int batch_size;
+  std::initializer_list<int> requests;
+  std::initializer_list<int> golden;
+
+  friend std::ostream& operator<<(std::ostream& os, const BatchConfig& self) {
+    os << "Batch Size: " << self.batch_size << ", ";
+    os << "Requests: {";
+    for (const auto& i : self.requests) {
+      os << i << ",";
+    }
+    os << "}, Golden: {";
+    for (const auto& i : self.golden) {
+      os << i << ",";
+    }
+    os << "}";
+    return os;
+  }
+};
+
+class UnitSoftBatcherFixture : public testing::TestWithParam<BatchConfig> {
  protected:
   void SetUp() override {
 #ifdef PROTEUS_ENABLE_LOGGING
@@ -52,13 +74,16 @@ class UnitSoftBatcherFixture
     initLogger(options);
 #endif
 
-    auto [batch_size, requests] = GetParam();
+    const auto& batch_config = GetParam();
+    int batch_size = batch_config.batch_size;
 
     const auto kBufferNum = 10;
     const auto kDataShape = {1UL, 2UL, 50UL};
-    const auto kDataSize = 100;
+    // the product of the data shape < 255 to fit into uint8
+    const uint8_t kDataSize = 100;
 
     this->data_size_ = kDataSize;
+    this->data_shape_ = kDataShape;
 
     RequestParameters parameters;
     parameters.put("timeout", kTimeoutMs);
@@ -85,13 +110,9 @@ class UnitSoftBatcherFixture
     this->batcher_->start(&this->worker_.value());
 
     data_.resize(kDataSize);
-    for (auto i = 0; i < kDataSize; i++) {
+    for (uint8_t i = 0; i < kDataSize; i++) {
       data_[i] = i;
     }
-
-    this->request_ = InferenceRequest();
-    this->request_.addInputTensor(static_cast<void*>(data_.data()), kDataShape,
-                                  DataType::UINT8);
   }
 
   void TearDown() override {
@@ -99,8 +120,20 @@ class UnitSoftBatcherFixture
     batcher_->end();
   }
 
-  void check_batch(int batches, int batch_size) {
-    for (auto i = 0; i < batches; i++) {
+  void compare_data(Buffer* tensor, int offset) const {
+    for (auto k = 0; k < data_size_; k++) {
+      auto data = *(static_cast<uint8_t*>(tensor->data(k + offset)));
+      EXPECT_EQ(data, k);
+    }
+  }
+
+  void check_batch() {
+    const auto& batch_config = GetParam();
+    auto requests = std::vector(batch_config.requests);
+    auto golden = batch_config.golden;
+
+    int tensor_index = 0;
+    for (const auto& i : golden) {
       BatchPtr batch;
       ASSERT_EQ(
         batcher_->getOutputQueue()->wait_dequeue_timed(batch, kTimeoutUs),
@@ -108,46 +141,83 @@ class UnitSoftBatcherFixture
 
       EXPECT_EQ(batch->input_buffers->size(), 1);
       EXPECT_EQ(batch->output_buffers->size(), 1);
-      EXPECT_EQ(batch->requests->size(), batch_size);
+      EXPECT_EQ(batch->requests->size(), i);
+
+      auto num_tensors = 0;
+      for (auto j = tensor_index; j < tensor_index + i; j++) {
+        num_tensors += requests[j];
+      }
+      tensor_index += i;
 
       for (const auto& buffer : *(batch->input_buffers)) {
         EXPECT_EQ(buffer.size(), 1);
-        auto& first_tensor = buffer[0];
-        for (auto j = 0; j < batch_size; j++) {
-          for (auto k = 0; k < data_size_; k++) {
-            auto data = *(static_cast<uint8_t*>(first_tensor->data(k)));
-            EXPECT_EQ(data, k);
-          }
+        auto& first_buffer = buffer[0];
+        for (auto j = 0; j < num_tensors; j++) {
+          compare_data(first_buffer.get(), j * data_size_);
         }
+      }
+
+      for (const auto& req : *(batch->requests)) {
+        req->runCallback(InferenceResponse());
       }
     }
   }
 
+  void enqueue(std::unique_ptr<CppNativeApi> req) {
+    batcher_->enqueue(std::move(req));
+  }
+
+  InferenceRequest create_request(int tensors) {
+    InferenceRequest request;
+    for (auto i = 0; i < tensors; ++i) {
+      request.addInputTensor(static_cast<void*>(data_.data()), data_shape_,
+                             DataType::UINT8);
+    }
+    return request;
+  }
+
+ private:
   int data_size_;
   std::vector<uint8_t> data_;
+  std::initializer_list<uint64_t> data_shape_;
   InferenceRequest request_;
   std::optional<WorkerInfo> worker_;
   std::optional<SoftBatcher> batcher_;
 };
 
 TEST_P(UnitSoftBatcherFixture, BasicBatching) {
-  auto [batch_size, num_requests] = GetParam();
-  const auto kLeftover = static_cast<int>(num_requests % batch_size != 0);
-  const auto kBatchCount = num_requests / batch_size + kLeftover;
+  const auto& batch_config = GetParam();
+  auto requests = batch_config.requests;
 
-  for (auto i = 0; i < num_requests; i++) {
-    auto req = std::make_unique<CppNativeApi>(this->request_);
-    batcher_->enqueue(std::move(req));
+  std::queue<InferenceResponseFuture> foo;
+  for (const auto& i : requests) {
+    auto request = create_request(i);
+    auto req = std::make_unique<CppNativeApi>(request);
+    this->enqueue(std::move(req));
   }
 
-  this->check_batch(kBatchCount - kLeftover, batch_size);
-  if (kLeftover) {
-    this->check_batch(kLeftover, num_requests % batch_size);
-  }
+  this->check_batch();
 }
 
-// pairs of (batch_size, num_requests)
-std::pair<int, int> configs[] = {{1, 1}, {1, 2}, {2, 1}, {2, 2}, {2, 3}};
+// batch size, requests, golden # tensors per response,
+/**
+ * The BatchConfig defines the configuration for the batcher. It has the
+ * following interpretation:
+ *
+ * {a, {b0, b1...bn}, {c0, c1... cm}}
+ *
+ * a: the configured batch size for the batcher
+ * b: this array defines the number of requests with request x having bx tensors
+ * c: this array defines that batch x will have cx requests with all
+ *    corresponding tensors associated with them from b
+ *
+ */
+const std::array<BatchConfig, 7> configs = {
+  BatchConfig{1, {1}, {1}},          BatchConfig{1, {1, 1}, {1, 1}},
+  BatchConfig{2, {1}, {1}},          BatchConfig{2, {1, 1}, {2}},
+  BatchConfig{2, {1, 1, 1}, {2, 1}}, BatchConfig{4, {3, 2}, {1, 1}},
+  BatchConfig{4, {2, 2}, {2}},
+};
 INSTANTIATE_TEST_SUITE_P(Datatypes, UnitSoftBatcherFixture,
                          testing::ValuesIn(configs));
 

--- a/tests/unit/batching/test_soft_batching.cpp
+++ b/tests/unit/batching/test_soft_batching.cpp
@@ -17,7 +17,6 @@
 #include <memory>    // for allocator, make_unique
 #include <numeric>   // for accumulate
 #include <optional>  // for optional
-#include <queue>     // for queue
 #include <utility>   // for pair, move
 #include <vector>    // for vector
 
@@ -189,7 +188,6 @@ TEST_P(UnitSoftBatcherFixture, BasicBatching) {
   const auto& batch_config = GetParam();
   auto requests = batch_config.requests;
 
-  std::queue<InferenceResponseFuture> foo;
   for (const auto& i : requests) {
     auto request = create_request(i);
     auto req = std::make_unique<CppNativeApi>(request);

--- a/tests/workers/test_aks.py
+++ b/tests/workers/test_aks.py
@@ -14,13 +14,13 @@
 
 import numpy as np
 import pytest
-
-import proteus
 from proteus.predict_api import (
     InferenceRequest,
     InferenceRequestInput,
     InferenceResponse,
 )
+
+import proteus
 
 
 @pytest.fixture(scope="class")
@@ -37,7 +37,7 @@ def parameters_fixture():
 @pytest.mark.extensions(["aks", "vitis"])
 class TestAks:
     def test_aks_0(self):
-        numbers = [3.0, 5.0]
+        numbers = [3.0]
         request = InferenceRequest()
         request.id = "hello_world"
 

--- a/tests/workers/test_migraphx.py
+++ b/tests/workers/test_migraphx.py
@@ -15,16 +15,15 @@
 import os
 import sys
 
-import pytest
-import numpy as np
-import proteus
 import cv2
+import numpy as np
+import pytest
+from helper import root_path, run_benchmark
 
-from helper import run_benchmark, root_path
+import proteus
 
 sys.path.insert(0, os.path.join(root_path, "examples/python"))
 from utils.utils import postprocess
-
 
 # The make_nxn and preprocess functions are based on an migraphx example at
 # AMDMIGraphx/examples/vision/python_resnet50/resnet50_inference.ipynb
@@ -57,7 +56,7 @@ def preprocess(img_data):
 
     Args:
         img_data (np.array): array in 3 dimensions [channels, rows, cols] with value range 0-255
-        The vectors are for RGB images, so images read with OpenCV must have channels 
+        The vectors are for RGB images, so images read with OpenCV must have channels
         converted before calling.
     Returns:
         Response: np.array
@@ -125,7 +124,7 @@ class TestMigraphx:
                 assert output.parameters.empty()
         return response
 
-    @pytest.mark.parametrize("num", [1, 8])
+    @pytest.mark.parametrize("num", [1])
     def test_migraphx(self, num):
         """
         Send a request to model as tensor data

--- a/tests/workers/test_ptzendnn.py
+++ b/tests/workers/test_ptzendnn.py
@@ -36,6 +36,7 @@ def parameters_fixture():
         "model": str(root_path / "external/pytorch_models/resnet50_pretrained.pt"),
         "input_size": 224,
         "output_classes": 1000,
+        "batch_size": 8,
     }
 
 

--- a/tests/workers/test_tfzendnn.py
+++ b/tests/workers/test_tfzendnn.py
@@ -15,14 +15,14 @@
 import os
 import sys
 
-import pytest
 import numpy as np
+import pytest
+from helper import root_path, run_benchmark
+
 import proteus
 
-from helper import run_benchmark, root_path
-
 sys.path.insert(0, os.path.join(root_path, "examples/python"))
-from utils.utils import preprocess, postprocess
+from utils.utils import postprocess, preprocess
 
 
 @pytest.fixture(scope="class")
@@ -42,6 +42,7 @@ def parameters_fixture():
         "output_classes": 1000,
         "inter_op": 64,
         "intra_op": 1,
+        "batch_size": 8,
     }
 
 


### PR DESCRIPTION
# Summary of Changes

*  Fix bug with the batcher batching larger than the requested batch size

Closes #53

# Motivation

Batcher should not produce a larger batch size than requested.

# Implementation

When dequeuing requests, if the new request would cause the current batch size to overflow, the request is saved in a second queue and the current batch is flushed. Then, on processing new requests, if this second queue is non-empty, the batcher will take from there first before continuing to dequeue as usual.

We also now explicitly disallow requests that are larger than the configured batch size. This behavior change will also help with supporting multiple input tensors.
