### PR TITLE
Update VAI examples to 2.5

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -59,6 +59,7 @@ Fixed
 - Get correct library dependencies for production container (:commit:`14ed4ef`)
 - Correctly throw an exception if a worker gets an error during initialization (:pr:`29`)
 - Detect errors in HTTP client during loading (:commit:`99ffc33`)
+- Construct batches with the right sizes (:pr:`57`)
 
 
 :github:`0.1.0 <Xilinx/inference-server/releases/tag/v0.1.0>` - 2022-02-08

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -182,7 +182,7 @@ if(CMAKE_BUILD_TYPE MATCHES Coverage)
     ${PROJECT_SOURCE_DIR}/tests/test.sh
     EXECUTABLE_ARGS
     --mode
-    all
+    tests
     --build
     Coverage
     --load-before
@@ -197,6 +197,8 @@ if(CMAKE_BUILD_TYPE MATCHES Coverage)
     EXCLUDE
     ${PROJECT_SOURCE_DIR}/build
     ${PROJECT_SOURCE_DIR}/tests
+    ${PROJECT_SOURCE_DIR}/external
+    ${PROJECT_SOURCE_DIR}/examples
   )
 else()
   message(STATUS "Not a coverage build, not configuring coverage measurement")

--- a/examples/python/custom_processing.py
+++ b/examples/python/custom_processing.py
@@ -93,7 +93,7 @@ def main():
     path_to_xmodel = "${PROTEUS_ROOT}/external/artifacts/u200_u250/resnet_v1_50_tf/resnet_v1_50_tf.xmodel"
     path_to_image = root + "/tests/assets/dog-3619020_640.jpg"
     # for this image, we know what we expect to receive with this XModel
-    gold_response_output = [259, 261, 260, 154, 230]
+    gold_response_output = [259, 261, 260, 157, 154]
     # -user variables
 
     client = proteus.clients.HttpClient("http://127.0.0.1:8998")

--- a/external/aks/reference/graph_zoo/graph_yolov3_u200_u250_proteus.json
+++ b/external/aks/reference/graph_zoo/graph_yolov3_u200_u250_proteus.json
@@ -22,7 +22,7 @@
       "node_name": "yolov3_fpga",
       "node_params": {
         "DPURunner": {
-          "model_file": "artifacts/u200_u250/yolov3_voc/yolov3_voc.xmodel",
+          "model_file": "artifacts/u200_u250/yolov3_voc_tf/yolov3_voc_tf.xmodel",
           "num_runners": 1
         }
       }

--- a/proteus
+++ b/proteus
@@ -16,11 +16,10 @@
 import argparse
 import getpass
 import glob
-import hashlib
+import importlib
 import json
 import multiprocessing as mp
 import os
-from pathlib import Path
 import pty
 import shlex
 import shutil
@@ -28,16 +27,25 @@ import subprocess
 import sys
 import tarfile
 import textwrap
-import time
 import urllib.error
 import urllib.request
 import zipfile
+from pathlib import Path
 
 
 def get_version():
+    """
+    Read the VERSION file and return as a string
+
+    Returns:
+        str: VERSION
+    """
     version_file = Path(__file__).parent.resolve() / "VERSION"
     with open(version_file, "r") as f:
         return f.readline().strip()
+
+
+help_message = "show this help message and exit"
 
 
 # https://stackoverflow.com/a/34736291/13621369
@@ -237,24 +245,6 @@ class WriteComposeFile:
                     config["services"][service], "devices", cls.get_devices()
                 )
 
-            # if args.user_config:
-            #     cls.set_or_extend(
-            #         config["services"][service], "volumes", cls.get_user_configs()
-            #     )
-
-            # if args.xclbins:
-            #     default_xclbin_path = "/opt/xilinx/overlaybins"
-            #     if Path(default_xclbin_path).exists():
-            #         mount = f"{default_xclbin_path}:{default_xclbin_path}:ro"
-            #         cls.set_or_extend(config["services"][service], "volumes", mount)
-
-            # if args.command:
-            #     cls.set_or_extend(
-            #         config["services"][service],
-            #         "command",
-            #         shlex.split(args.command.strip('"')),
-            #     )
-
         if args.dry_run:
             print(json.dumps(config, indent=2))
         else:
@@ -262,10 +252,19 @@ class WriteComposeFile:
                 yaml.dump(config, f)
 
 
+def reject_unknown_args(unknown_args):
+    if unknown_args:
+        unknown_arguments = " ".join(unknown_args)
+        raise argparse.ArgumentError(
+            None, f"Unknown argument(s) passed: {unknown_arguments}"
+        )
+
+
 class Attach:
     @staticmethod
     def parse(args, unknown_args):
-        user = getpass.getuser()
+        reject_unknown_args(unknown_args)
+
         cmd = f"docker ps --filter status=running --filter 'label=project=proteus' --latest --quiet"
         if args.name is None:
             try:
@@ -299,14 +298,13 @@ class Attach:
 
         command_group = subparser.add_argument_group("Options")
         command_group.add_argument(
-            "-n",
-            "--name",
+            "name",
             action="store",
+            default=None,
+            nargs="?",
             help="name of the container to attach to. Defaults to latest running container",
         )
-        command_group.add_argument(
-            "-h", "--help", action="help", help="show this help message and exit"
-        )
+        command_group.add_argument("-h", "--help", action="help", help=help_message)
         subparser.set_defaults(func=cls.parse)
 
 
@@ -370,9 +368,8 @@ class Build:
             run_command(command, args.dry_run)
 
         # if the package isn't importable, then we need to delete the CMake cache so the package can be installed by the build
-        try:
-            import proteus
-        except ImportError:
+        package_installed = importlib.util.find_spec("proteus")
+        if package_installed is None:
             args.regen = True
 
         cmake_cache = build_dir / "CMakeCache.txt"
@@ -495,67 +492,7 @@ class Build:
             help="number of threads for Make (defaults to number of processors)",
             default=mp.cpu_count(),
         )
-        command_group.add_argument(
-            "-h", "--help", action="help", help="show this help message and exit"
-        )
-        subparser.set_defaults(func=cls.parse)
-
-
-class ClangFormat:
-    @staticmethod
-    def parse(args, unknown_args):
-        unknown_commands = " ".join(unknown_args)
-        command = f"clang-format -style=file -i {unknown_commands} {args.path}"
-        run_command(command, args.dry_run)
-
-    @classmethod
-    def add(cls, parser):
-        subparser = parser.add_parser(
-            "clangformat",
-            help="Run clangformat on a file",
-            add_help=False,
-            description="This is a wrapper around clangformat to format a particular file in place based on the existing clangformat rules. Any unmatched arguments are passed to clang-format. Use clang-format --help to see options",
-        )
-        subparser.add_argument(
-            "path", action="store", help="Path to a C++ file to analyze"
-        )
-
-        command_group = subparser.add_argument_group("Options")
-        command_group.add_argument(
-            "-h", "--help", action="help", help="show this help message and exit"
-        )
-        subparser.set_defaults(func=cls.parse)
-
-
-class ClangTidy:
-    @staticmethod
-    def parse(args, unknown_args):
-        _, old_build_config, _ = get_build_config(args.dir)
-        if old_build_config is None:
-            old_build_config = "Debug"
-
-        unknown_commands = " ".join(unknown_args)
-        command = f"clang-tidy -format-style=file -p={args.dir}/{old_build_config} {unknown_commands}"
-        run_command(command, args.dry_run)
-
-    @classmethod
-    def add(cls, parser):
-        subparser = parser.add_parser(
-            "clangtidy", help="Run clang-tidy on all source files", add_help=False
-        )
-
-        command_group = subparser.add_argument_group("Options")
-        command_group.add_argument(
-            "-d",
-            "--dir",
-            action="store",
-            help="root path to the build tree. Defaults to ./build",
-            default=str(Path.cwd() / "build"),
-        )
-        command_group.add_argument(
-            "-h", "--help", action="help", help="show this help message and exit"
-        )
-
+        command_group.add_argument("-h", "--help", action="help", help=help_message)
         subparser.set_defaults(func=cls.parse)
 
 
@@ -605,11 +542,9 @@ class Clean:
         command_group.add_argument(
             "--artifacts",
             action="store_true",
-            help="Delete downloaded XModel artifacts",
+            help="Delete downloaded artifacts",
         )
-        command_group.add_argument(
-            "-h", "--help", action="help", help="show this help message and exit"
-        )
+        command_group.add_argument("-h", "--help", action="help", help=help_message)
         command_group.add_argument(
             "--no-gui",
             dest="gui",
@@ -704,9 +639,7 @@ class Dockerize:
             help=f"Name of the image to use as dev image to build the production image.",
             default="",
         )
-        command_group.add_argument(
-            "-h", "--help", action="help", help="show this help message and exit"
-        )
+        command_group.add_argument("-h", "--help", action="help", help=help_message)
         command_group.add_argument(
             "--vitis",
             dest="vitis",
@@ -761,13 +694,57 @@ class Dockerize:
 
 class Get:
     @staticmethod
+    def _download(args, url, tmp_dir, location, filename):
+        if args.dry_run:
+            print(f"Downloading {filename} from {url} to {location}")
+            return
+        with open(tmp_dir / filename, "wb") as f:
+            req = urllib.request.Request(url)
+            # need to specify the user-agent for accessing wikimedia
+            req.add_header("User-Agent", f"proteus {get_version()}")
+            response = urllib.request.urlopen(req)
+            f.write(response.read())
+
+        filepath = str(tmp_dir / filename)
+        if filename.endswith("tar.gz"):
+            tar_file = tarfile.open(filepath, mode="r:gz")
+            tar_file.extractall(location)
+        elif filename.endswith("zip"):
+            with zipfile.ZipFile(str(tmp_dir / filename), "r") as zip_ref:
+                zip_ref.extractall(str(tmp_dir))
+            model_path = str(tmp_dir / filename.split(".zip")[0] / "float/")
+            for filename in os.listdir(model_path):
+                modelname = (
+                    filename
+                    if filename.endswith("pb") or filename.endswith("pth")
+                    else None
+                )
+            if not os.path.exists(location):
+                os.makedirs(location)
+            shutil.move(
+                os.path.join(model_path, modelname),
+                os.path.join(location, modelname),
+            )
+            if modelname.endswith("pth"):
+                run_command(
+                    f"{sys.executable} -m pip install -r tools/zendnn/requirements.txt",
+                    args.dry_run,
+                )
+                import tools.zendnn.convert_to_torchscript as converter
+
+                converter_args = argparse.Namespace
+                converter_args.graph = os.path.join(location, modelname)
+                converter.main(converter_args)
+        else:
+            shutil.copy2(filepath, str(location / filename))
+            os.remove(filepath)
+        if not args.quiet:
+            print(f"Downloaded {url} to {str(location/filename)}")
+
+    @staticmethod
     def parse(args, unknown_args):
 
-        if unknown_args:
-            unknown_arguments = " ".join(unknown_args)
-            raise argparse.ArgumentError(
-                None, f"Unknown argument(s) passed: {unknown_arguments}"
-            )
+        reject_unknown_args(unknown_args)
 
         if not args.dry_run:
             print(
@@ -804,10 +781,9 @@ class Get:
                 "https://cdn.pixabay.com/photo/2016/11/29/03/35/girl-1867092_640.jpg",
             ],
             alveo_dir: [
-                "https://www.xilinx.com/bin/public/openDownload?filename=densebox_320_320-u200-u250-r1.4.0.tar.gz",
-                "https://www.xilinx.com/bin/public/openDownload?filename=resnet_v1_50_tf-u200-u250-r1.4.0.tar.gz",
-                "https://www.xilinx.com/bin/public/openDownload?filename=yolov3_adas_pruned_0_9-u200-u250-r1.4.0.tar.gz",
-                "https://www.xilinx.com/bin/public/openDownload?filename=yolov3_voc-u200-u250-r1.4.0.tar.gz",
+                "https://www.xilinx.com/bin/public/openDownload?filename=densebox_320_320-u200-u250-r2.5.0.tar.gz",
+                "https://www.xilinx.com/bin/public/openDownload?filename=resnet_v1_50_tf-u200-u250-r2.5.0.tar.gz",
+                "https://www.xilinx.com/bin/public/openDownload?filename=yolov3_voc_tf-u200-u250-r2.5.0.tar.gz",
             ],
             tmp_dir: [
                 "https://www.xilinx.com/bin/public/openDownload?filename=vitis_ai_runtime_r1.3.0_image_video.tar.gz",
@@ -831,57 +807,8 @@ class Get:
                     filename = url[url.index(search_str) + len(search_str) :]
                 else:
                     filename = os.path.basename(urllib.parse.urlparse(url).path)
-                if args.dry_run:
-                    print(f"Downloading {filename} from {url} to {location}")
-                else:
-                    with open(tmp_dir / filename, "wb") as f:
-                        req = urllib.request.Request(url)
-                        # need to specify the user-agent for accessing wikimedia
-                        req.add_header("User-Agent", f"proteus {get_version()}")
-                        response = urllib.request.urlopen(req)
-                        f.write(response.read())
 
-                    filepath = str(tmp_dir / filename)
-                    if filename.endswith("tar.gz"):
-                        tar_file = tarfile.open(filepath, mode="r:gz")
-                        tar_file.extractall(location)
-                    elif filename.endswith("zip"):
-                        with zipfile.ZipFile(str(tmp_dir / filename), "r") as zip_ref:
-                            zip_ref.extractall(str(tmp_dir))
-                        modelpath = str(tmp_dir / filename.split(".zip")[0] / "float/")
-                        for filename in os.listdir(modelpath):
-                            modelname = (
-                                filename
-                                if filename.endswith("pb") or filename.endswith("pth")
-                                else None
-                            )
-                        if not os.path.exists(location):
-                            os.makedirs(location)
-                        shutil.move(
-                            os.path.join(modelpath, modelname),
-                            os.path.join(location, modelname),
-                        )
-                        if modelname.endswith("pth"):
-                            subprocess.check_call(
-                                [
-                                    sys.executable,
-                                    "-m",
-                                    "pip",
-                                    "install",
-                                    "-r",
-                                    "tools/zendnn/requirements.txt",
-                                ]
-                            )
-                            import tools.zendnn.convert_to_torchscript as converter
-
-                            converter_args = argparse.Namespace
-                            converter_args.graph = os.path.join(location, modelname)
-                            converter.main(converter_args)
-                    else:
-                        shutil.copy2(filepath, str(location / filename))
-                        os.remove(filepath)
-                    if not args.quiet:
-                        print(f"Downloaded {url} to {str(location/filename)}")
+                Get._download(args, url, tmp_dir, location, filename)
 
         if not args.dry_run:
             adas_webm = Path(tmp_dir / "adas_detection/video/adas.webm")
@@ -901,9 +828,7 @@ class Get:
         )
 
         command_group = subparser.add_argument_group("Options")
-        command_group.add_argument(
-            "-h", "--help", action="help", help="show this help message and exit"
-        )
+        command_group.add_argument("-h", "--help", action="help", help=help_message)
 
         command_group.add_argument(
             "-q", "--quiet", action="store_true", help="suppress prints"
@@ -963,9 +888,7 @@ class Install:
             action="store_true",
             help="Print the list of files last installed.",
         )
-        command_group.add_argument(
-            "-h", "--help", action="help", help="show this help message and exit"
-        )
+        command_group.add_argument("-h", "--help", action="help", help=help_message)
 
         subparser.set_defaults(func=cls.parse)
 
@@ -984,7 +907,7 @@ class List:
             if shutil.which("jq") is not None:
                 run_shell_command(command, args.dry_run)
             else:
-                print("Install jq to use this command")
+                raise argparse.ArgumentError(None, "Install jq to use this command")
         else:
             if unknown_args:
                 command += " ".join(unknown_args)
@@ -1008,9 +931,7 @@ class List:
         )
 
         command_group = subparser.add_argument_group("Options")
-        command_group.add_argument(
-            "-h", "--help", action="help", help="show this help message and exit"
-        )
+        command_group.add_argument("-h", "--help", action="help", help=help_message)
 
         subparser.set_defaults(func=cls.parse)
 
@@ -1044,9 +965,7 @@ class Make:
             help="root path to the build tree. Defaults to ./build",
             default=str(Path.cwd() / "build"),
         )
-        command_group.add_argument(
-            "-h", "--help", action="help", help="show this help message and exit"
-        )
+        command_group.add_argument("-h", "--help", action="help", help=help_message)
         command_group.add_argument(
             "-j",
             dest="jobs",
@@ -1061,6 +980,30 @@ class Make:
 
 class Run:
     @staticmethod
+    def dict_to_flags(flags: dict):
+        command = ""
+        for key, value in flags.items():
+            if not value:
+                continue
+            if isinstance(value, list):
+                for item in value:
+                    command += f"--{key} {item} "
+            elif isinstance(value, dict):
+                items = []
+                for _, value_2 in value.items():
+                    if isinstance(value_2, list):
+                        items.extend(value_2)
+                    else:
+                        items.append(value_2)
+                for item in items:
+                    command += f"--{key} {item} "
+            elif value is True:
+                command += f"--{key} "
+            else:
+                command += f"--{key} {value} "
+        return command
+
+    @staticmethod
     def parse(args, unknown_args: list):
         if args.image is None and args.preset is None:
             raise argparse.ArgumentError(
@@ -1070,6 +1013,7 @@ class Run:
         flags = {}
         image = None
         cmd = None
+        root_dir = "/workspace/proteus"
         if args.preset == "dev":
             image = f"{getpass.getuser()}/proteus-dev:latest"
             flags["cap-add"] = "SYS_PTRACE"
@@ -1081,17 +1025,17 @@ class Run:
             flags["tty"] = True
             flags["volume"] = {
                 "user_config": WriteComposeFile.get_user_configs(),
-                "working_dir": f"{Path.cwd()}:/workspace/proteus",
+                "working_dir": f"{Path.cwd()}:{root_dir}",
                 "xclbins": WriteComposeFile.get_xclbins(),
             }
-            flags["workdir"] = "/workspace/proteus"
+            flags["workdir"] = root_dir
         elif args.preset == "autotest-dev":
             cmd = "./tools/coverage.sh -t 50"
             image = f"{getpass.getuser()}/proteus-dev:latest"
             flags["volume"] = {
-                "working_dir": f"{Path.cwd()}:/workspace/proteus",
+                "working_dir": f"{Path.cwd()}:{root_dir}",
             }
-            flags["workdir"] = "/workspace/proteus"
+            flags["workdir"] = root_dir
 
         # if a preset was used, use the default image if no explicit image was provided.
         if args.image is None:
@@ -1114,10 +1058,10 @@ class Run:
 
         if args.working_dir is not None:
             if args.working_dir:
-                flags["volume"]["working_dir"] = f"{Path.cwd()}:/workspace/proteus"
+                flags["volume"]["working_dir"] = f"{Path.cwd()}:{root_dir}"
             else:
                 flags["volume"]["working_dir"] = False
-                if flags["workdir"] == "/workspace/proteus":
+                if flags["workdir"] == root_dir:
                     flags["workdir"] = False
         if args.xclbins is not None:
             if args.xclbins:
@@ -1141,25 +1085,7 @@ class Run:
         columns, lines = shutil.get_terminal_size()
         command = f"docker run -e COLUMNS={columns} -e LINES={lines} "
 
-        for key, value in flags.items():
-            if not value:
-                continue
-            if isinstance(value, list):
-                for item in value:
-                    command += f"--{key} {item} "
-            elif isinstance(value, dict):
-                items = []
-                for _, value_2 in value.items():
-                    if isinstance(value_2, list):
-                        items.extend(value_2)
-                    else:
-                        items.append(value_2)
-                for item in items:
-                    command += f"--{key} {item} "
-            elif value is True:
-                command += f"--{key} "
-            else:
-                command += f"--{key} {value} "
+        command += Run.dict_to_flags(flags)
 
         command += " ".join(unknown_args)
         command += " " + args.image
@@ -1220,9 +1146,7 @@ class Run:
             help="Pass devices from host to container, if they exist",
             default=None,
         )
-        command_group.add_argument(
-            "-h", "--help", action="help", help="show this help message and exit"
-        )
+        command_group.add_argument("-h", "--help", action="help", help=help_message)
         command_group.add_argument(
             "--image",
             action="store",
@@ -1309,9 +1233,7 @@ class Start:
             help="root path to the build tree. Defaults to ./build",
             default=str(Path.cwd() / "build"),
         )
-        command_group.add_argument(
-            "-h", "--help", action="help", help="show this help message and exit"
-        )
+        command_group.add_argument("-h", "--help", action="help", help=help_message)
         command_group.add_argument(
             "--gdb",
             action="store_true",
@@ -1410,9 +1332,7 @@ class Up:
         )
 
         command_group = subparser.add_argument_group("Options")
-        command_group.add_argument(
-            "-h", "--help", action="help", help="show this help message and exit"
-        )
+        command_group.add_argument("-h", "--help", action="help", help=help_message)
         command_group.add_argument(
             "-p",
             "--profile",
@@ -1460,8 +1380,6 @@ def get_parser():
     Attach.add(subparser)
     Benchmark.add(subparser)
     Build.add(subparser)
-    ClangFormat.add(subparser)
-    ClangTidy.add(subparser)
     Clean.add(subparser)
     Dockerize.add(subparser)
     Get.add(subparser)
@@ -1479,9 +1397,7 @@ def get_parser():
         action="store_true",
         help="print the actual commands that would be run without running them",
     )
-    command_group.add_argument(
-        "-h", "--help", action="help", help="show this help message and exit"
-    )
+    command_group.add_argument("-h", "--help", action="help", help=help_message)
     command_group.add_argument(
         "-v",
         "--version",

--- a/src/proteus/core/api.cpp
+++ b/src/proteus/core/api.cpp
@@ -138,8 +138,8 @@ Kernels getHardware() {
   }
   std::string response_str;
   response_str.resize(total_len);
-  auto foo = conn.read_n(response_str.data(), total_len);
-  if (foo == -1) {
+  auto bytes_read = conn.read_n(response_str.data(), total_len);
+  if (bytes_read == -1) {
     throw external_error("wrong number of bytes read at data");
   }
 
@@ -178,11 +178,11 @@ Kernels getHardware() {
 bool hasHardware(const std::string& name, int num) {
   auto kernels = getHardware();
 
-  auto foo = kernels.find(name);
-  if (foo == kernels.end()) {
+  auto kernel_iterator = kernels.find(name);
+  if (kernel_iterator == kernels.end()) {
     return false;
   }
-  return foo->second >= num;
+  return kernel_iterator->second >= num;
 }
 
 }  // namespace proteus

--- a/src/proteus/core/manager.cpp
+++ b/src/proteus/core/manager.cpp
@@ -98,8 +98,8 @@ ModelMetadata Manager::getWorkerMetadata(const std::string& key) {
   if (worker == nullptr) {
     throw invalid_argument("Worker " + key + " not found");
   }
-  auto* foo = worker->workers_.begin()->second;
-  return foo->getMetadata();
+  auto* worker_class = worker->workers_.begin()->second;
+  return worker_class->getMetadata();
 }
 
 void Manager::workerAllocate(std::string const& key, int num) {

--- a/tests/api/CMakeLists.txt
+++ b/tests/api/CMakeLists.txt
@@ -35,5 +35,5 @@ foreach(target ${targets})
   )
   target_link_libraries(${target} PRIVATE proteus gtest gtest_main)
 
-  gtest_discover_tests(${target})
+  gtest_discover_tests(${target} DISCOVERY_TIMEOUT 30)
 endforeach()

--- a/tests/src/proteus/core/manager.cpp
+++ b/tests/src/proteus/core/manager.cpp
@@ -58,8 +58,8 @@ ModelMetadata Manager::getWorkerMetadata(const std::string& key) {
   if (worker == nullptr) {
     throw invalid_argument("Worker " + key + " not found");
   }
-  auto* foo = worker->workers_.begin()->second;
-  return foo->getMetadata();
+  auto* worker_class = worker->workers_.begin()->second;
+  return worker_class->getMetadata();
 }
 
 void Manager::workerAllocate(std::string const& key, int num) {

--- a/tests/workers/test_ptzendnn.py
+++ b/tests/workers/test_ptzendnn.py
@@ -107,7 +107,7 @@ class TestPtZendnn:
             assert (top_k == gold_response_output).all()
 
     @pytest.mark.benchmark(group="PtZendnn")
-    def test_benchmark_xmodel(self, benchmark, model_fixture, parameters_fixture):
+    def test_benchmark_ptzendnn(self, benchmark, model_fixture, parameters_fixture):
 
         batch_size = 16
         input_size = parameters_fixture.get("input_size")

--- a/tests/workers/test_resnet50_dpucadf8h.py
+++ b/tests/workers/test_resnet50_dpucadf8h.py
@@ -12,11 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pytest
-
 import numpy as np
+import pytest
+from helper import root_path, run_benchmark
 
-from helper import run_benchmark, root_path
 import proteus
 
 
@@ -62,7 +61,7 @@ class TestInferImageResNet50DPUCADF8H:
             )
 
         num_inputs = len(request.getInputs())
-        gold_response_output = [259, 261, 154, 260, 204]
+        gold_response_output = [259, 261, 154, 152, 204]
 
         if check_asserts:
             assert not response.isError(), response.getError()

--- a/tests/workers/test_resnet50_stream.py
+++ b/tests/workers/test_resnet50_stream.py
@@ -15,10 +15,10 @@
 import json
 
 import pytest
-
 from helper import root_path
+from proteus.predict_api import InferenceRequest, InferenceRequestInput
+
 import proteus
-from proteus.predict_api import InferenceRequestInput, InferenceRequest
 
 
 @pytest.fixture(scope="class")
@@ -68,8 +68,8 @@ class TestResnet50Stream:
         for i in range(count):
             resp_str = self.ws_client.modelRecv()
             resp = json.loads(resp_str)
-            foo = resp["data"]["img"]
-            if len(foo) > 50:
+            data = resp["data"]["img"]
+            if len(data) > 50:
                 print(f"{i} got an image")
             else:
                 print(resp)

--- a/tests/workers/test_xmodel.py
+++ b/tests/workers/test_xmodel.py
@@ -12,13 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pytest
 import math
 
 import cv2
 import numpy as np
+import pytest
+from helper import root_path, run_benchmark
 
-from helper import run_benchmark, root_path
 import proteus
 
 
@@ -164,7 +164,7 @@ class TestXmodel:
         assert output.datatype == proteus.DataType.INT8
         data = output.getInt8Data()
         k = self.postprocess(data, 5)
-        gold_response_output = [259, 261, 260, 154, 230]
+        gold_response_output = [259, 261, 260, 157, 154]
         assert k == gold_response_output
 
     @pytest.mark.benchmark(group="xmodel")

--- a/tests/workers/test_yolov3.py
+++ b/tests/workers/test_yolov3.py
@@ -12,12 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pytest
 import json
 import os
-import numpy as np
 
-from helper import run_benchmark, root_path
+import numpy as np
+import pytest
+from helper import root_path, run_benchmark
+
 import proteus
 
 
@@ -63,36 +64,20 @@ class TestInferImageYoloV3DPUCADF8H:
             )
 
         num_inputs = len(request.getInputs())
-        # for this picture and xmodel combination, we expect the following output with Vitis 1.4
+        # for this picture and xmodel combination, we expect the following output with Vitis 2.5
         gold_response_output = [
             1,
-            0.7396191358566284,
-            192.97344970703125,
-            198.21803283691406,
-            167.64910888671875,
-            130.1903839111328,
+            0.9823938,
+            200.2854,
+            213.84378,
+            178.46155,
+            107.93164,
             14,
-            0.9992860555648804,
-            232.0582733154297,
-            148.03860473632812,
-            109.48860168457031,
-            161.711181640625,
-        ]
-
-        # for this picture and xmodel combination, we expect the following output with Vitis 2.0
-        gold_response_output_2 = [
-            1,
-            0.9974043369293213,
-            220.02317810058594,
-            213.84378051757812,
-            138.98597717285156,
-            107.931640625,
-            14,
-            0.9992860555648804,
-            232.0582733154297,
-            148.03860473632812,
-            109.48860168457031,
-            161.711181640625,
+            0.99329937,
+            240.7067,
+            154.99591,
+            90.769196,
+            142.7096,
         ]
 
         if check_asserts:
@@ -110,9 +95,7 @@ class TestInferImageYoloV3DPUCADF8H:
                 num_boxes = int(len(data) / 6)
                 assert output.shape == [6, num_boxes]
                 assert len(data) == len(gold_response_output)
-                assert np.allclose(data, gold_response_output, 0.01, 0) or np.allclose(
-                    data, gold_response_output_2, 0.01, 0
-                )
+                assert np.allclose(data, gold_response_output, 0.01, 0)
         return response
 
     def construct_request(self, asTensor):

--- a/tools/coverage.sh
+++ b/tools/coverage.sh
@@ -61,7 +61,7 @@ coverage(){
     ./proteus get
   fi
 
-  ./proteus build --coverage --regen --clean --all
+  ./proteus build --coverage --regen --clean
   ./proteus make coverage
 
   cd -


### PR DESCRIPTION
# Summary of Changes

*  Updates the Vitis AI examples to use 2.5 models (and 2.5 xclbins)
*  Fix segmentation fault bug

Closes #54 
Closes #31 

# Motivation

The previous examples used VAI 1.4 which required users to also have compatible xclbins. Using 2.5 models allows the server to use the latest models.

# Implementation

The models to download are updated and the golden values for tests/examples are updated as well.

The segmentation fault bug in the the `proteus` script was due to the check on whether the `proteus` package could be imported: it would attempt to import the package and if the import failed, it would rerun the CMake build. However, when the package was imported, the subsequent uninstall and reinstallation of the bindings during the CMake build resulted in a segmentation fault. Now, the package's importability is checked without actually importing it.
