### PR TITLE
Add check for LFS artifacts before testing

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -28,6 +28,13 @@ Added
 ^^^^^
 
 - Allow building Debian package (:commit:`930fab2`)
+- Add ``modelInferAsync`` to the API (:commit:`2f4a6c2`)
+
+Changed
+^^^^^^^
+
+- Use input tensors in requests correctly (:pr:`61`)
+
 
 :github:`0.2.0 <Xilinx/inference-server/releases/tag/v0.2.0>` - 2022-08-05
 --------------------------------------------------------------------------

--- a/proteus
+++ b/proteus
@@ -803,6 +803,11 @@ class Get:
             ],
         }
 
+        if run_command("git lfs version", args.dry_run) is None:
+            run_command("git lfs pull", args.dry_run)
+        else:
+            print("Git LFS not found, not automatically getting LFS artifacts")
+
         for location, urls in files.items():
             for url in urls:
                 if "www.xilinx.com/bin/public/openDownload" in url:

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -80,6 +80,20 @@ if [[ -z $LD_LIBRARY_PATH && -f ~/.env ]]; then
   source ~/.env
 fi
 
+# make sure Git LFS artifacts are downloaded
+jpgs=($(find $root_path/tests/assets/ -name "*.jpg"))
+for jpg in ${jpgs[@]}; do
+  if file $jpg | grep "ASCII" &> /dev/null; then
+    if git lfs version &> /dev/null; then
+      git lfs pull
+    else
+      "Git LFS artifacts are not present and git lfs is not installed"
+      exit 1
+    fi
+  fi
+done
+
+
 # if the python package doesn't exist, do a build first for the BUILD variable
 if ! pip list | grep proteus &> /dev/null; then
   cd $root_path


### PR DESCRIPTION
# Summary of Changes

*  Add check in the tests script to make sure LFS artifacts are present
*  Get LFS artifacts with `proteus get`

Closes #22

# Motivation

LFS artifacts may not be downloaded automatically with `git pull` if the host isn't configured that way. Here, I resolve it by invoking `git lfs pull` automatically when the other test artifacts are downloaded or before running the tests.

# Implementation

See PR
