### PR TITLE
Fix making parallel requests using the HTTP client

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Copyright 2021 Xilinx Inc.
+# Copyright 2022 Advanced Micro Devices Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -78,7 +79,7 @@ include(EnableIPO)
 include(AddOption)
 
 # check requirements
-find_package(Drogon)
+find_package(Drogon CONFIG)
 find_package(OpenCV)
 find_package(opentelemetry-cpp CONFIG)
 find_package(spdlog)

--- a/Dockerfile
+++ b/Dockerfile
@@ -290,7 +290,7 @@ RUN apt-get update \
     # symlink libjsoncpp to json to maintain include compatibility with Drogon
     && cp -rfs /usr/include/jsoncpp/json/ /usr/include/ \
     # install drogon
-    && cd /tmp && git clone -b v1.8.0 https://github.com/an-tao/drogon \
+    && cd /tmp && git clone -b v1.7.5 https://github.com/an-tao/drogon \
     && cd drogon \
     && git submodule update --init --recursive \
     && mkdir -p build && cd build \
@@ -299,7 +299,9 @@ RUN apt-get update \
         -DCMAKE_INSTALL_PREFIX=/usr/local \
         -DCMAKE_BUILD_TYPE=Release \
         -DBUILD_ORM=OFF \
-        -DBUILD_SHARED_LIBS=ON \
+        -DBUILD_DROGON_SHARED=ON \
+        # this is used instead of the above in 1.8.0+
+        # -DBUILD_SHARED_LIBS=ON \
         -DBUILD_CTL=OFF \
     && make -j$(($(nproc) - 1)) \
     && make install \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 # Copyright 2021 Xilinx Inc.
+# Copyright 2022 Advanced Micro Devices Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -289,7 +290,7 @@ RUN apt-get update \
     # symlink libjsoncpp to json to maintain include compatibility with Drogon
     && cp -rfs /usr/include/jsoncpp/json/ /usr/include/ \
     # install drogon
-    && cd /tmp && git clone -b v1.7.5 https://github.com/an-tao/drogon \
+    && cd /tmp && git clone -b v1.8.0 https://github.com/an-tao/drogon \
     && cd drogon \
     && git submodule update --init --recursive \
     && mkdir -p build && cd build \
@@ -298,7 +299,7 @@ RUN apt-get update \
         -DCMAKE_INSTALL_PREFIX=/usr/local \
         -DCMAKE_BUILD_TYPE=Release \
         -DBUILD_ORM=OFF \
-        -DBUILD_DROGON_SHARED=ON \
+        -DBUILD_SHARED_LIBS=ON \
         -DBUILD_CTL=OFF \
     && make -j$(($(nproc) - 1)) \
     && make install \

--- a/cmake/AddTest.cmake
+++ b/cmake/AddTest.cmake
@@ -1,0 +1,82 @@
+# Copyright 2022 Advanced Micro Devices, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+function(proteus_get_test_target target test)
+  string(REGEX REPLACE "^${PROTEUS_TEST_ROOT}" "" BASE_PATH
+                       ${CMAKE_CURRENT_SOURCE_DIR}
+  )
+  string(REGEX REPLACE "\/" "_" BASE_NAME ${BASE_PATH})
+
+  # check for an extra argument to set the prefix. use 'test' by default
+  list(LENGTH ARGN extra_count)
+  if(extra_count GREATER 0)
+    list(GET ARGN 0 prefix)
+  elseif(extra_count GREATER 1)
+    message(FATAL_ERROR "Cannot pass more than two arguments to this function")
+  else()
+    set(prefix "test")
+  endif()
+
+  set(${target} ${prefix}${BASE_NAME}-${test} PARENT_SCOPE)
+endfunction()
+
+function(_proteus_add_test test type)
+  proteus_get_test_target(target ${test})
+
+  add_executable(${target} test_${test}.cpp)
+  if(${type} STREQUAL "unit")
+    target_include_directories(
+      ${target} BEFORE PRIVATE ${PROTEUS_TEST_INCLUDE_DIRS}
+    )
+    target_include_directories(${target} AFTER PRIVATE ${PROTEUS_INCLUDE_DIRS})
+  elseif(${type} STREQUAL "system")
+    target_include_directories(${target} BEFORE PRIVATE ${PROTEUS_INCLUDE_DIRS})
+    target_include_directories(
+      ${target} AFTER PRIVATE ${PROTEUS_TEST_INCLUDE_DIRS}
+    )
+    target_link_libraries(${target} PRIVATE proteus)
+  else()
+    message(FATAL_ERROR "Test type must be one of 'unit' or 'system'")
+  endif()
+
+  target_link_libraries(${target} PRIVATE gtest gtest_main)
+
+  gtest_discover_tests(${target} DISCOVERY_TIMEOUT 30)
+endfunction()
+
+function(proteus_add_system_test test)
+  _proteus_add_test(${test} "system")
+endfunction()
+
+function(proteus_add_unit_test test)
+  _proteus_add_test(${test} "unit")
+endfunction()
+
+function(proteus_add_system_tests tests)
+  foreach(test ${tests})
+    proteus_add_system_test(${test})
+  endforeach()
+endfunction()
+
+function(proteus_add_unit_tests tests tests_libs)
+  foreach(test lib_str IN ZIP_LISTS tests tests_libs)
+
+    string(REPLACE "~" ";" libs ${lib_str})
+
+    proteus_add_unit_test(${test})
+    proteus_get_test_target(target ${test})
+
+    target_link_libraries(${target} PRIVATE ${libs})
+  endforeach()
+endfunction()

--- a/cmake/AddTest.cmake
+++ b/cmake/AddTest.cmake
@@ -72,7 +72,8 @@ endfunction()
 function(proteus_add_unit_tests tests tests_libs)
   foreach(test lib_str IN ZIP_LISTS tests tests_libs)
 
-    string(REPLACE "~" ";" libs ${lib_str})
+    string(REPLACE " " "" libs_no_spaces ${lib_str})
+    string(REPLACE "~" ";" libs ${libs_no_spaces})
 
     proteus_add_unit_test(${test})
     proteus_get_test_target(target ${test})

--- a/docker-compose.autotest.yml
+++ b/docker-compose.autotest.yml
@@ -26,7 +26,7 @@ services:
       - $PWD/external/artifacts:/opt/xilinx/proteus/artifacts:ro
       - $PWD/tests/assets:/workspace/proteus/tests/assets:ro
   proteus-tester:
-    command: [./tests/test.sh, --hostname, proteus]
+    command: [./tests/test.sh, --hostname, proteus, --cpp, skip]
     depends_on:
       - proteus
     extra_hosts:

--- a/docs/dependencies.rst
+++ b/docs/dependencies.rst
@@ -1,5 +1,6 @@
 ..
     Copyright 2021 Xilinx Inc.
+    Copyright 2022 Advanced Micro Devices Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -152,7 +153,7 @@ The following packages are installed from Github.
     :github:`cameron314/concurrentqueue`,1.0.3,Dual BSD-2/Boost + others,Statically linked by proteus-server for an efficient multi-producer queue\ :superscript:`a 0`
     :github:`jarro2783/cxxopts`,2.2.1,MIT,Statically linked by proteus-server for command-line argument parsing\ :superscript:`a 0`
     :github:`gdraheim/docker-systemctl-replacement`,1.5.4505,EUPL,Executable created by pyinstaller for starting XRM\ :superscript:`a 0`
-    :github:`drogonframework/drogon`,1.7.5,MIT,Dynamically linked by proteus-server for an HTTP and websocket server\ :superscript:`a 0`
+    :github:`drogonframework/drogon`,1.8.0,MIT,Dynamically linked by proteus-server for an HTTP and websocket server\ :superscript:`a 0`
     :github:`SpartanJ/efsw`,latest,MIT,Dynamically linked by proteus-server for directory monitoring\ :superscript:`a 0`
     :github:`FFmpeg/FFmpeg`,3.4.8,LGPL-2.1+ + others,Dynamically linked by proteus-server for video processing\ :superscript:`a 0`
     :github:`tschaub/gh-pages`,latest,MIT,Executable used to publish documentation to gh-pages branch\ :superscript:`d 0`

--- a/include/proteus/clients/http.hpp
+++ b/include/proteus/clients/http.hpp
@@ -1,4 +1,5 @@
 // Copyright 2022 Xilinx Inc.
+// Copyright 2022 Advanced Micro Devices Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -47,7 +48,8 @@ namespace proteus {
 
 class HttpClient : public Client {
  public:
-  HttpClient(std::string address, const StringMap& headers = {});
+  HttpClient(std::string address, const StringMap& headers = {},
+             int threads = 2);
   HttpClient(HttpClient const&);
   HttpClient& operator=(const HttpClient&) = delete;
   HttpClient(HttpClient&& other) noexcept;

--- a/include/proteus/clients/http.hpp
+++ b/include/proteus/clients/http.hpp
@@ -49,7 +49,7 @@ namespace proteus {
 class HttpClient : public Client {
  public:
   HttpClient(std::string address, const StringMap& headers = {},
-             int threads = 2);
+             int parallelism = 32);
   HttpClient(HttpClient const&);
   HttpClient& operator=(const HttpClient&) = delete;
   HttpClient(HttpClient&& other) noexcept;

--- a/include/proteus/servers/server.hpp
+++ b/include/proteus/servers/server.hpp
@@ -1,4 +1,5 @@
 // Copyright 2022 Xilinx Inc.
+// Copyright 2022 Advanced Micro Devices Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -26,7 +27,9 @@ class Server {
   ~Server();
 
   void startHttp(uint16_t port) const;
+  void stopHttp() const;
   void startGrpc(uint16_t port) const;
+  void stopGrpc() const;
 
  private:
   class ServerImpl;

--- a/proteus
+++ b/proteus
@@ -366,7 +366,8 @@ class Build:
         if args.lint:
             build_options += " -DPROTEUS_ENABLE_LINTING=ON"
 
-        if args.clean and build_dir.exists():
+        cmake_cache = build_dir / "CMakeCache.txt"
+        if args.clean and cmake_cache.exists():
             command = (
                 f"cmake --build {str(build_dir)} --target clean -- -j {args.threads}"
             )
@@ -377,7 +378,6 @@ class Build:
         if package_installed is None:
             args.regen = True
 
-        cmake_cache = build_dir / "CMakeCache.txt"
         if args.regen or (not build_dir.exists()) or (not cmake_cache.exists()):
             file = f"{str(build_dir)}/CMakeCache.txt"
             command = f"rm -f {str(cmake_cache)}"

--- a/src/proteus/clients/http.cpp
+++ b/src/proteus/clients/http.cpp
@@ -1,4 +1,5 @@
 // Copyright 2021 Xilinx Inc.
+// Copyright 2022 Advanced Micro Devices Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,6 +20,7 @@
 
 #include "proteus/clients/http.hpp"
 
+#include <drogon/HttpAppFramework.h>      // for HttpAppFramework, app
 #include <drogon/HttpClient.h>            // for HttpClient, HttpClientPtr
 #include <drogon/HttpRequest.h>           // for HttpRequest, HttpReques...
 #include <drogon/HttpResponse.h>          // for HttpResponse
@@ -26,9 +28,11 @@
 #include <json/value.h>                   // for Value, arrayValue, obje...
 #include <trantor/net/EventLoopThread.h>  // for EventLoopThread
 
+#include <atomic>
 #include <cassert>        // for assert
 #include <unordered_set>  // for unordered_set
 #include <utility>        // for tuple_element<>::type
+#include <vector>
 
 #include "proteus/clients/http_internal.hpp"  // for mapParametersToJson
 #include "proteus/core/exceptions.hpp"        // for bad_status
@@ -43,26 +47,52 @@ void addHeaders(drogon::HttpRequestPtr req, const StringMap& headers) {
 
 class HttpClient::HttpClientImpl {
  public:
-  explicit HttpClientImpl(const std::string& address) {
-    loop_.run();
-    client_ = drogon::HttpClient::newHttpClient(address, loop_.getLoop());
+  explicit HttpClientImpl(const std::string& address, int threads) {
+    // arbitrarily use ratio of 4:1 between HttpClients and EventLoops
+    const auto kClientThreadRatio = 4;
+
+    num_clients_ = threads * kClientThreadRatio;
+    loops_.reserve(threads);
+    clients_.reserve(num_clients_);
+    for (auto i = 0; i < threads; ++i) {
+      // need to use unique_ptr because EventLoopThreads are not moveable or
+      // copyable and so incompatible with std::vectors
+      const auto& loop =
+        loops_.emplace_back(std::make_unique<trantor::EventLoopThread>());
+      loop->run();
+    }
+    for (auto i = 0; i < num_clients_; ++i) {
+      const auto& loop = loops_[i % threads];
+      clients_.emplace_back(
+        drogon::HttpClient::newHttpClient(address, loop->getLoop()));
+    }
   }
 
-  drogon::HttpClient* getClient() { return client_.get(); }
+  drogon::HttpClient* getClient() {
+    const auto& client = clients_[counter_];
+    counter_ = (counter_ + 1) % num_clients_;
+    return client.get();
+  }
+
+  auto getClientNum() const { return num_clients_; }
 
  private:
-  trantor::EventLoopThread loop_;
-  drogon::HttpClientPtr client_;
+  int counter_ = 0;
+  int num_clients_ = 4;
+  std::vector<std::unique_ptr<trantor::EventLoopThread>> loops_;
+  std::vector<drogon::HttpClientPtr> clients_;
 };
 
-HttpClient::HttpClient(std::string address, const StringMap& headers)
+HttpClient::HttpClient(std::string address, const StringMap& headers,
+                       int threads)
   : address_(std::move(address)), headers_(headers) {
-  this->impl_ = std::make_unique<HttpClient::HttpClientImpl>(address_);
+  this->impl_ = std::make_unique<HttpClient::HttpClientImpl>(address_, threads);
 }
 
 HttpClient::HttpClient(const HttpClient& other)
   : address_(other.address_), headers_(other.headers_) {
-  this->impl_ = std::make_unique<HttpClient::HttpClientImpl>(address_);
+  this->impl_ = std::make_unique<HttpClient::HttpClientImpl>(
+    address_, other.impl_->getClientNum());
 }
 
 HttpClient::HttpClient(HttpClient&& other) noexcept
@@ -239,15 +269,42 @@ void HttpClient::workerUnload(const std::string& model) {
   }
 }
 
-InferenceResponse runInference(drogon::HttpClient* client,
-                               const std::string& model,
-                               const InferenceRequest& request,
-                               const StringMap& headers) {
+auto createInferenceRequest(const std::string& model,
+                            const InferenceRequest& request,
+                            const StringMap& headers) {
   assert(!request.getInputs().empty());
 
   auto json = mapRequestToJson(request);
-  auto req = createPostRequest(json, "/v2/models/" + model + "/infer", headers);
+  return createPostRequest(json, "/v2/models/" + model + "/infer", headers);
+}
 
+InferenceResponseFuture HttpClient::modelInferAsync(
+  const std::string& model, const InferenceRequest& request) {
+  auto req = createInferenceRequest(model, request, headers_);
+  auto prom = std::make_shared<std::promise<proteus::InferenceResponse>>();
+  auto fut = prom->get_future();
+
+  auto* client = this->impl_->getClient();
+  client->sendRequest(
+    req, [prom = std::move(prom)](drogon::ReqResult result,
+                                  const drogon::HttpResponsePtr& response) {
+      check_error(result);
+      if (response->statusCode() != drogon::k200OK) {
+        throw bad_status(std::string(response->body()));
+      }
+
+      auto resp = response->jsonObject();
+      prom->set_value(mapJsonToResponse(resp.get()));
+    });
+
+  return fut;
+}
+
+InferenceResponse HttpClient::modelInfer(const std::string& model,
+                                         const InferenceRequest& request) {
+  auto req = createInferenceRequest(model, request, headers_);
+
+  auto* client = this->impl_->getClient();
   auto [result, response] = client->sendRequest(req);
   check_error(result);
   if (response->statusCode() != drogon::k200OK) {
@@ -256,17 +313,6 @@ InferenceResponse runInference(drogon::HttpClient* client,
 
   auto resp = response->jsonObject();
   return mapJsonToResponse(resp.get());
-}
-
-InferenceResponseFuture HttpClient::modelInferAsync(
-  const std::string& model, const InferenceRequest& request) {
-  return std::async(runInference, this->impl_->getClient(), model, request,
-                    headers_);
-}
-
-InferenceResponse HttpClient::modelInfer(const std::string& model,
-                                         const InferenceRequest& request) {
-  return runInference(this->impl_->getClient(), model, request, headers_);
 }
 
 std::vector<std::string> HttpClient::modelList() {

--- a/src/proteus/core/worker_info.cpp
+++ b/src/proteus/core/worker_info.cpp
@@ -1,4 +1,5 @@
 // Copyright 2021 Xilinx Inc.
+// Copyright 2022 Advanced Micro Devices Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -94,6 +95,7 @@ WorkerInfo::WorkerInfo(const std::string& name, RequestParameters* parameters) {
 }
 
 WorkerInfo::~WorkerInfo() {
+  batchers_.clear();
   for (const auto& [thread_id, worker] : workers_) {
     delete worker;  // NOLINT(cppcoreguidelines-owning-memory)
   }

--- a/src/proteus/servers/server.cpp
+++ b/src/proteus/servers/server.cpp
@@ -1,4 +1,5 @@
 // Copyright 2022 Xilinx Inc.
+// Copyright 2022 Advanced Micro Devices Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -97,20 +98,8 @@ Server::Server() {
 }
 
 Server::~Server() {
-#ifdef PROTEUS_ENABLE_HTTP
-  if (impl_->http_started_) {
-    http::stop();
-    if (impl_->http_thread_.joinable()) {
-      impl_->http_thread_.join();
-    }
-  }
-#endif
-#ifdef PROTEUS_ENABLE_GRPC
-  if (impl_->grpc_started_) {
-    grpc::stop();
-  }
-
-#endif
+  stopHttp();
+  stopGrpc();
   terminate();
 }
 
@@ -123,11 +112,30 @@ void Server::startHttp([[maybe_unused]] uint16_t port) const {
 #endif
 }
 
+void Server::stopHttp() const {
+#ifdef PROTEUS_ENABLE_HTTP
+  if (impl_->http_started_) {
+    http::stop();
+    if (impl_->http_thread_.joinable()) {
+      impl_->http_thread_.join();
+    }
+  }
+#endif
+}
+
 void Server::startGrpc([[maybe_unused]] uint16_t port) const {
 #ifdef PROTEUS_ENABLE_HTTP
   if (!impl_->grpc_started_) {
     grpc::start(port);
     impl_->grpc_started_ = true;
+  }
+#endif
+}
+
+void Server::stopGrpc() const {
+#ifdef PROTEUS_ENABLE_GRPC
+  if (impl_->grpc_started_) {
+    grpc::stop();
   }
 #endif
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,4 +1,5 @@
-# Copyright 2021 Xilinx Inc.
+# Copyright 2021 Xilinx, Inc.
+# Copyright 2021 Advanced Micro Devices, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,6 +14,9 @@
 # limitations under the License.
 
 set(PROTEUS_TEST_INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/src)
+set(PROTEUS_TEST_ROOT ${CMAKE_CURRENT_SOURCE_DIR})
+
+include(AddTest)
 
 add_subdirectory(api)
 add_subdirectory(models)

--- a/tests/api/CMakeLists.txt
+++ b/tests/api/CMakeLists.txt
@@ -1,4 +1,5 @@
-# Copyright 2022 Xilinx Inc.
+# Copyright 2022 Xilinx, Inc.
+# Copyright 2022 Advanced Micro Devices, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,28 +14,15 @@
 # limitations under the License.
 
 list(
-  APPEND targets
-         test_model_infer
-         test_model_infer_async
-         test_model_list
-         test_model_ready
-         test_server_live
-         test_server_ready
-         test_model_metadata
+  APPEND tests
+         model_infer
+         model_infer_async
+         model_list
+         model_load
+         model_metadata
+         model_ready
+         server_live
+         server_ready
 )
 
-if(${PROTEUS_ENABLE_TFZENDNN})
-  list(APPEND targets test_model_load)
-endif()
-
-foreach(target ${targets})
-  add_executable(${target} ${target}.cpp)
-
-  target_include_directories(
-    ${target} PRIVATE ${PROTEUS_PUBLIC_INCLUDE_DIRS}
-                      ${PROTEUS_TEST_INCLUDE_DIRS}
-  )
-  target_link_libraries(${target} PRIVATE proteus gtest gtest_main)
-
-  gtest_discover_tests(${target} DISCOVERY_TIMEOUT 30)
-endforeach()
+proteus_add_system_tests("${tests}")

--- a/tests/api/test_model_load.cpp
+++ b/tests/api/test_model_load.cpp
@@ -1,4 +1,5 @@
-// Copyright 2022 Xilinx Inc.
+// Copyright 2022 Xilinx, Inc.
+// Copyright 2022 Advanced Micro Devices, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -21,6 +22,11 @@
 #include "proteus/testing/gtest_fixtures.hpp"  // for AssertionResult, Suite...
 
 void test(proteus::Client* client) {
+  auto metadata = client->serverMetadata();
+  if (metadata.extensions.find("tfzendnn") == metadata.extensions.end()) {
+    GTEST_SKIP() << "This test requires TF+ZenDNN support.";
+  }
+
   const std::string model = "mnist";
 
   EXPECT_TRUE(client->modelList().empty());

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -59,6 +59,7 @@ def pytest_addoption(parser):
     parser.addoption("--fpgas", action="store", default="")
     parser.addoption("--benchmark", action="store", default="skip")
     parser.addoption("--perf", action="store", default="skip")
+    parser.addoption("--cpp", action="store", default="all")
 
     # TODO(varunsh): this is currently not exposed via the test runner script
     parser.addoption("--skip-extensions", nargs="+", default=[])
@@ -79,7 +80,7 @@ def get_http_addr(config):
     return f"{hostname}:{http_port}"
 
 
-def add_cpp_markers(items):
+def add_cpp_markers(items, cpp_mode):
     """
     For all the collected items, if the item is a C++ test, find its
     corresponding source file (assuming it has a matching name). If found,
@@ -87,9 +88,21 @@ def add_cpp_markers(items):
 
     Args:
         items (list): list of Nodes from pytest_collection_modifyitems
+        cpp_mode (str): skip | all | only
     """
     for item in items:
         if not isinstance(item, CppItem):
+            if cpp_mode == "only":
+                skip_bench = pytest.mark.skip(
+                    reason=f"Not a cpp test: use --cpp [all, skip] to run"
+                )
+                item.add_marker(skip_bench)
+            continue
+        if cpp_mode == "skip":
+            skip_bench = pytest.mark.skip(
+                reason=f"A cpp test: use --cpp [all, only] to run"
+            )
+            item.add_marker(skip_bench)
             continue
         test_dir = str(item.fspath).replace(str(build_path), str(root_path))
         # this test naming syntax is defined in cmake/AddTest.cmake
@@ -142,7 +155,7 @@ def pytest_collection_modifyitems(config, items):
     global http_server_addr
     global proteus_command
 
-    add_cpp_markers(items)
+    add_cpp_markers(items, config.getoption("--cpp"))
 
     client = proteus.clients.HttpClient(http_server_addr)
     if not client.serverLive():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
-# Copyright 2021 Xilinx Inc.
+# Copyright 2021 Xilinx, Inc.
+# Copyright 2022 Advanced Micro Devices, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -90,7 +91,10 @@ def add_cpp_markers(items):
     for item in items:
         if not isinstance(item, CppItem):
             continue
-        source_path = str(item.fspath).replace(str(build_path), str(root_path)) + ".cpp"
+        test_dir = str(item.fspath).replace(str(build_path), str(root_path))
+        # this test naming syntax is defined in cmake/AddTest.cmake
+        test_file = "test_" + item.fspath.basename.split("-")[1]
+        source_path = test_dir.replace(item.fspath.basename, test_file) + ".cpp"
         if not os.path.exists(source_path):
             continue
         with open(source_path) as f:

--- a/tests/models/CMakeLists.txt
+++ b/tests/models/CMakeLists.txt
@@ -1,4 +1,5 @@
-# Copyright 2021 Xilinx Inc.
+# Copyright 2021 Xilinx, Inc.
+# Copyright 2022 Advanced Micro Devices, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,25 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-list(APPEND targets)
+list(APPEND tests mnist)
 
-if(${PROTEUS_ENABLE_TFZENDNN})
-  list(APPEND targets mnist)
-endif()
-
-foreach(target ${targets})
-  add_executable(test_${target} test_${target}.cpp)
+foreach(test ${tests})
+  proteus_add_system_test(${test})
+  proteus_get_test_target(target ${test})
   target_link_libraries(
-    test_${target} PRIVATE proteus Threads::Threads gtest gtest_main
+    ${target} PRIVATE opencv_imgcodecs opencv_imgproc opencv_core
   )
-  target_include_directories(
-    test_${target} PRIVATE ${PROTEUS_PUBLIC_INCLUDE_DIRS}
-                           ${PROTEUS_TEST_INCLUDE_DIRS}
-  )
-
-  gtest_discover_tests(test_${target})
 endforeach()
-
-if(${PROTEUS_ENABLE_TFZENDNN})
-  target_link_libraries(test_mnist PRIVATE opencv_core opencv_imgcodecs)
-endif()

--- a/tests/models/test_mnist.cpp
+++ b/tests/models/test_mnist.cpp
@@ -1,4 +1,5 @@
-// Copyright 2022 Xilinx Inc.
+// Copyright 2022 Xilinx, Inc.
+// Copyright 2022 Advanced Micro Devices, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -27,6 +28,11 @@
 namespace proteus {
 
 void test(proteus::Client* client) {
+  auto metadata = client->serverMetadata();
+  if (metadata.extensions.find("tfzendnn") == metadata.extensions.end()) {
+    GTEST_SKIP() << "This test requires TF+ZenDNN support.";
+  }
+
   const std::string model = "mnist";
 
   EXPECT_TRUE(client->modelList().empty());

--- a/tests/performance/batching/CMakeLists.txt
+++ b/tests/performance/batching/CMakeLists.txt
@@ -1,4 +1,5 @@
-# Copyright 2021 Xilinx Inc.
+# Copyright 2021 Xilinx, Inc.
+# Copyright 2022 Advanced Micro Devices, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,25 +13,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-list(APPEND targets perf_soft)
+list(APPEND tests soft)
 
 list(
   APPEND
-    targets_libs
-    "$<TARGET_OBJECTS:fake_worker_info_buffers_finite>~fake_observation~fake_manager~interface~predict_api~data_types~$<TARGET_OBJECTS:softBatcher>~vector_buffer~buffer~$<TARGET_OBJECTS:native_internal>"
+    tests_libs
+    "$<TARGET_OBJECTS:batcher>~fake_observation~fake_manager~interface\
+      ~$<TARGET_OBJECTS:fake_worker_info_buffers_finite>~predict_api~data_types\
+      ~$<TARGET_OBJECTS:softBatcher>~vector_buffer~buffer\
+      ~$<TARGET_OBJECTS:native_internal>"
 )
 
-foreach(target lib_str IN ZIP_LISTS targets targets_libs)
-  string(REPLACE "~" ";" libs ${lib_str})
-
-  add_executable(${target} ${target}.cpp)
-  target_include_directories(
-    ${target} BEFORE PRIVATE ${PROTEUS_TEST_INCLUDE_DIRS}
-  )
-  target_include_directories(${target} AFTER PRIVATE ${PROTEUS_INCLUDE_DIRS})
-  target_link_libraries(
-    ${target} $<TARGET_OBJECTS:batcher> ${libs} gtest gtest_main
-  )
-
-  gtest_discover_tests(${target})
-endforeach()
+proteus_add_unit_tests("${tests}" "${tests_libs}")

--- a/tests/performance/batching/test_soft.cpp
+++ b/tests/performance/batching/test_soft.cpp
@@ -92,6 +92,12 @@ class PerfSoftBatcherFixture
     parameters.put("timeout", kTimeoutMs);
     parameters.put("batch_size", batch_size);
 
+    LogOptions options;
+    options.logger_name = "server";
+    options.console_enable = true;
+    options.file_enable = false;
+    initLogger(options);
+
     this->batcher_.emplace(&parameters);
     this->batcher_->setName("test");
     this->batcher_->setBatchSize(batch_size);

--- a/tests/performance/batching/test_soft.cpp
+++ b/tests/performance/batching/test_soft.cpp
@@ -1,4 +1,5 @@
-// Copyright 2021 Xilinx Inc.
+// Copyright 2021 Xilinx, Inc.
+// Copyright 2022 Advanced Micro Devices, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/performance/models/CMakeLists.txt
+++ b/tests/performance/models/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2022 Advanced Micro Devices Inc.
+# Copyright 2022 Advanced Micro Devices, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,25 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-list(APPEND targets resnet50)
+list(APPEND tests resnet50)
 
-foreach(target ${targets})
-  set(test test_PerfModels${target})
-
-  add_executable(${test} ${target}.cpp)
-  target_include_directories(
-    ${test} BEFORE PRIVATE ${PROTEUS_TEST_INCLUDE_DIRS}
-  )
-  target_include_directories(${test} AFTER PRIVATE ${PROTEUS_INCLUDE_DIRS})
+foreach(test ${tests})
+  proteus_add_system_test(${test})
+  proteus_get_test_target(target ${test})
   target_link_libraries(
-    ${test}
-    proteus
-    gtest
-    gtest_main
-    opencv_imgcodecs
-    opencv_imgproc
-    opencv_core
+    ${target} PRIVATE opencv_imgcodecs opencv_imgproc opencv_core
   )
-
-  gtest_discover_tests(${test})
 endforeach()

--- a/tests/performance/models/CMakeLists.txt
+++ b/tests/performance/models/CMakeLists.txt
@@ -1,4 +1,3 @@
-# Copyright 2022 Xilinx Inc.
 # Copyright 2022 Advanced Micro Devices Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,5 +12,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_subdirectory(batching)
-add_subdirectory(models)
+list(APPEND targets resnet50)
+
+foreach(target ${targets})
+  set(test testPerfModels${target})
+
+  add_executable(${test} ${target}.cpp)
+  target_include_directories(
+    ${test} BEFORE PRIVATE ${PROTEUS_TEST_INCLUDE_DIRS}
+  )
+  target_include_directories(${test} AFTER PRIVATE ${PROTEUS_INCLUDE_DIRS})
+  target_link_libraries(
+    ${test}
+    proteus
+    gtest
+    gtest_main
+    opencv_imgcodecs
+    opencv_imgproc
+    opencv_core
+  )
+
+  gtest_discover_tests(${test})
+endforeach()

--- a/tests/performance/models/CMakeLists.txt
+++ b/tests/performance/models/CMakeLists.txt
@@ -15,7 +15,7 @@
 list(APPEND targets resnet50)
 
 foreach(target ${targets})
-  set(test testPerfModels${target})
+  set(test test_PerfModels${target})
 
   add_executable(${test} ${target}.cpp)
   target_include_directories(

--- a/tests/performance/models/resnet50.cpp
+++ b/tests/performance/models/resnet50.cpp
@@ -1,0 +1,123 @@
+// Copyright 2022 Advanced Micro Devices Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file
+ * @brief Performance testing for the native client
+ */
+
+#include <chrono>
+#include <filesystem>
+#include <queue>
+#include <string>
+#include <vector>
+
+#include "proteus/client_operators/infer_async.hpp"
+#include "proteus/proteus.hpp"                 // for InferenceResponse, Grp...
+#include "proteus/testing/gtest_fixtures.hpp"  // for GrpcFixture
+#include "proteus/util/ctpl.h"                 // for thread_pool
+#include "proteus/util/pre_post/image_preprocess.hpp"
+
+namespace fs = std::filesystem;
+
+void test(proteus::Client* client) {
+  const fs::path kRoot{std::getenv("PROTEUS_ROOT")};
+
+  // for this resnet50 model, use the following values
+  const std::string worker{"ptzendnn"};
+  const auto kGraph = kRoot / "external/pytorch_models/resnet50_pretrained.pt";
+  const auto kImageLocation = kRoot / "tests/assets/dog-3619020_640.jpg";
+  const auto kInputSize = 224;
+  const auto kOutputClasses = 1000;
+  const auto kBatchSize = 20;
+
+  const auto kWarmupRequests = 4;
+  const auto kRequests = 40;
+
+  proteus::RequestParameters parameters;
+  parameters.put("model", kGraph.string());
+  parameters.put("input_size", kInputSize);
+  parameters.put("output_classes", kOutputClasses);
+  parameters.put("batch_size", kBatchSize);
+
+  auto endpoint = client->workerLoad(worker, &parameters);
+  EXPECT_EQ(endpoint, worker);
+
+  std::vector<std::string> paths{kImageLocation};
+  proteus::util::ImagePreprocessOptions<float, 3> options_;
+  options_.normalize = true;
+  options_.order = proteus::util::ImageOrder::NCHW;
+  options_.mean = {0.485, 0.456, 0.406};
+  options_.std = {4.367, 4.464, 4.444};
+  options_.convert_color = true;
+  options_.color_code = cv::COLOR_BGR2RGB;
+  options_.convert_type = true;
+  options_.type = CV_32FC3;
+  options_.convert_scale = 1.0 / 255.0;
+  auto images = proteus::util::imagePreprocess(paths, options_);
+
+  proteus::InferenceRequest request;
+  request.addInputTensor(images[0].data(), {3, kInputSize, kInputSize},
+                         proteus::DataType::FLOAT32);
+
+  // warm up
+  for (auto i = 0; i < kWarmupRequests; ++i) {
+    client->modelInfer(worker, request);
+  }
+
+  auto start = std::chrono::high_resolution_clock::now();
+  for (auto i = 0; i < kRequests; ++i) {
+    auto response = client->modelInfer(worker, request);
+    EXPECT_FALSE(response.isError());
+  }
+  auto stop = std::chrono::high_resolution_clock::now();
+  std::chrono::duration<double, std::milli> duration = stop - start;
+  std::cout << "-----\n";
+  std::cout << "sync average time taken for images: " << duration.count()
+            << "ms" << std::endl;
+  std::cout << "-----\n";
+
+  std::vector<proteus::InferenceRequest> requests;
+  requests.reserve(kRequests);
+  for (auto i = 0; i < kRequests; ++i) {
+    requests.push_back(request);
+  }
+  start = std::chrono::high_resolution_clock::now();
+  auto responses = proteus::inferAsyncOrdered(client, worker, requests);
+  stop = std::chrono::high_resolution_clock::now();
+  duration = stop - start;
+  std::cout << "-----\n";
+  std::cout << "async average time taken for images: " << duration.count()
+            << "ms" << std::endl;
+  std::cout << "-----\n";
+}
+
+#ifdef PROTEUS_ENABLE_GRPC
+// @pytest.mark.perf(group="clients")
+// NOLINTNEXTLINE(cert-err58-cpp, cppcoreguidelines-owning-memory)
+TEST_F(GrpcFixture, ModelInfer) { test(client_.get()); }
+#endif
+
+// @pytest.mark.perf(group="clients")
+// NOLINTNEXTLINE(cert-err58-cpp, cppcoreguidelines-owning-memory)
+TEST_F(BaseFixture, ModelInfer) {
+  proteus::NativeClient client;
+  test(&client);
+}
+
+#ifdef PROTEUS_ENABLE_HTTP
+// @pytest.mark.perf(group="clients")
+// NOLINTNEXTLINE(cert-err58-cpp, cppcoreguidelines-owning-memory)
+TEST_F(HttpFixture, ModelInfer) { test(client_.get()); }
+#endif

--- a/tests/performance/models/resnet50.cpp
+++ b/tests/performance/models/resnet50.cpp
@@ -31,61 +31,135 @@
 
 namespace fs = std::filesystem;
 
-void test(proteus::Client* client) {
+struct Config {
+  int batch_size;
+  int requests;
+
+  friend std::ostream& operator<<(std::ostream& os, const Config& self) {
+    os << "Batch Size: " << self.batch_size << ", ";
+    os << "Requests: " << self.requests << ", ";
+    return os;
+  }
+};
+
+template <typename T, int C>
+using ImagePreprocessOptions = proteus::util::ImagePreprocessOptions<T, C>;
+
+struct Workers {
+  const fs::path kRoot{std::getenv("PROTEUS_ROOT")};
+  std::string name;
+  fs::path graph;
+
+  proteus::RequestParameters parameters;
+  std::variant<ImagePreprocessOptions<float, 3>> preprocessing;
+};
+
+struct PtzendnnWorker : public Workers {
+  PtzendnnWorker() {
+    name = "ptzendnn";
+    graph = kRoot / "external/pytorch_models/resnet50_pretrained.pt";
+
+    parameters.put("model", graph.string());
+
+    proteus::util::ImagePreprocessOptions<float, 3> options;
+    options.normalize = true;
+    options.order = proteus::util::ImageOrder::NCHW;
+    options.mean = {0.485, 0.456, 0.406};
+    options.std = {4.367, 4.464, 4.444};
+    options.convert_color = true;
+    options.color_code = cv::COLOR_BGR2RGB;
+    options.convert_type = true;
+    options.type = CV_32FC3;
+    options.convert_scale = 1.0 / 255.0;
+    preprocessing = options;
+  }
+};
+
+struct TfzendnnWorker : public Workers {
+  TfzendnnWorker() {
+    name = "tfzendnn";
+    graph =
+      kRoot / "external/tensorflow_models/resnet_v1_50_baseline_6.96B_922.pb";
+
+    parameters.put("model", graph.string());
+    parameters.put("input_node", "input");
+    parameters.put("output_node", "resnet_v1_50/predictions/Reshape_1");
+    parameters.put("inter_op", 64);
+    parameters.put("intra_op", 1);
+
+    proteus::util::ImagePreprocessOptions<float, 3> options;
+    options.convert_color = true;
+    options.color_code = cv::COLOR_BGR2RGB;
+    options.assign = true;
+    preprocessing = options;
+  }
+};
+
+class PerfModelsResnetBaseFixture
+  : public BaseFixtureWithParams<std::tuple<Config, Workers*>> {};
+class PerfModelsResnetHttpFixture
+  : public HttpFixtureWithParams<std::tuple<Config, Workers*>> {};
+class PerfModelsResnetGrpcFixture
+  : public GrpcFixtureWithParams<std::tuple<Config, Workers*>> {};
+
+template <class... Fs>
+struct Overload : Fs... {
+  using Fs::operator()...;
+};
+template <class... Fs>
+Overload(Fs...) -> Overload<Fs...>;
+
+void test(proteus::Client* client, const Config& config, Workers* worker) {
   const fs::path kRoot{std::getenv("PROTEUS_ROOT")};
 
-  // for this resnet50 model, use the following values
-  const std::string worker{"ptzendnn"};
-  const auto kGraph = kRoot / "external/pytorch_models/resnet50_pretrained.pt";
   const auto kImageLocation = kRoot / "tests/assets/dog-3619020_640.jpg";
   const auto kInputSize = 224;
   const auto kOutputClasses = 1000;
-  const auto kBatchSize = 20;
+  const auto kBatchSize = config.batch_size;
 
   const auto kWarmupRequests = 4;
-  const auto kRequests = 40;
+  const auto kRequests = config.requests;
 
-  proteus::RequestParameters parameters;
-  parameters.put("model", kGraph.string());
+  const auto& name = worker->name;
+
+  auto& parameters = worker->parameters;
   parameters.put("input_size", kInputSize);
   parameters.put("output_classes", kOutputClasses);
   parameters.put("batch_size", kBatchSize);
 
-  auto endpoint = client->workerLoad(worker, &parameters);
-  EXPECT_EQ(endpoint, worker);
+  auto endpoint = client->workerLoad(name, &parameters);
+  EXPECT_EQ(endpoint, name);
 
   std::vector<std::string> paths{kImageLocation};
-  proteus::util::ImagePreprocessOptions<float, 3> options_;
-  options_.normalize = true;
-  options_.order = proteus::util::ImageOrder::NCHW;
-  options_.mean = {0.485, 0.456, 0.406};
-  options_.std = {4.367, 4.464, 4.444};
-  options_.convert_color = true;
-  options_.color_code = cv::COLOR_BGR2RGB;
-  options_.convert_type = true;
-  options_.type = CV_32FC3;
-  options_.convert_scale = 1.0 / 255.0;
-  auto images = proteus::util::imagePreprocess(paths, options_);
+  auto& options = worker->preprocessing;
 
   proteus::InferenceRequest request;
-  request.addInputTensor(images[0].data(), {3, kInputSize, kInputSize},
-                         proteus::DataType::FLOAT32);
+  std::visit(
+    Overload{
+      [&](const ImagePreprocessOptions<float, 3>& options_) {
+        auto images = proteus::util::imagePreprocess(paths, options_);
+        request.addInputTensor(images[0].data(), {3, kInputSize, kInputSize},
+                               proteus::DataType::FLOAT32);
+      },
+    },
+    options);
 
   // warm up
   for (auto i = 0; i < kWarmupRequests; ++i) {
-    client->modelInfer(worker, request);
+    client->modelInfer(endpoint, request);
   }
 
   auto start = std::chrono::high_resolution_clock::now();
   for (auto i = 0; i < kRequests; ++i) {
-    auto response = client->modelInfer(worker, request);
+    auto response = client->modelInfer(endpoint, request);
     EXPECT_FALSE(response.isError());
   }
   auto stop = std::chrono::high_resolution_clock::now();
   std::chrono::duration<double, std::milli> duration = stop - start;
   std::cout << "-----\n";
-  std::cout << "sync average time taken for images: " << duration.count()
-            << "ms" << std::endl;
+  std::cout << "sync time taken for " << kRequests << " images with batch size "
+            << kBatchSize << " on " << name << ": " << duration.count() << "ms"
+            << std::endl;
   std::cout << "-----\n";
 
   std::vector<proteus::InferenceRequest> requests;
@@ -94,30 +168,67 @@ void test(proteus::Client* client) {
     requests.push_back(request);
   }
   start = std::chrono::high_resolution_clock::now();
-  auto responses = proteus::inferAsyncOrdered(client, worker, requests);
+  auto responses = proteus::inferAsyncOrdered(client, endpoint, requests);
   stop = std::chrono::high_resolution_clock::now();
   duration = stop - start;
   std::cout << "-----\n";
-  std::cout << "async average time taken for images: " << duration.count()
-            << "ms" << std::endl;
+  std::cout << "async time taken for " << kRequests
+            << " images with batch size " << kBatchSize << " on " << name
+            << ": " << duration.count() << "ms" << std::endl;
   std::cout << "-----\n";
+
+  client->workerUnload(endpoint);
+  while (client->modelReady(endpoint)) {
+    std::this_thread::sleep_for(std::chrono::seconds(1));
+  }
 }
+
+const std::array<Config, 4> configs = {Config{1, 10}, Config{2, 20},
+                                       Config{20, 40}, Config{40, 40}};
+
+inline static PtzendnnWorker ptzendnn;
+inline static TfzendnnWorker tfzendnn;
+
+const std::array<Workers*, 1> workers = {
+  // TODO(amuralee): why does TFzendnn slow down dramatically if included
+  // together
+  //  &ptzendnn, &tfzendnn
+  &tfzendnn};
 
 #ifdef PROTEUS_ENABLE_GRPC
 // @pytest.mark.perf(group="clients")
 // NOLINTNEXTLINE(cert-err58-cpp, cppcoreguidelines-owning-memory)
-TEST_F(GrpcFixture, ModelInfer) { test(client_.get()); }
+TEST_P(PerfModelsResnetGrpcFixture, ModelInfer) {
+  const auto& [config, worker] = GetParam();
+  test(client_.get(), config, worker);
+}
+
+INSTANTIATE_TEST_SUITE_P(PerfModelsResnetGrpc, PerfModelsResnetGrpcFixture,
+                         testing::Combine(testing::ValuesIn(configs),
+                                          testing::ValuesIn(workers)));
 #endif
 
 // @pytest.mark.perf(group="clients")
 // NOLINTNEXTLINE(cert-err58-cpp, cppcoreguidelines-owning-memory)
-TEST_F(BaseFixture, ModelInfer) {
+TEST_P(PerfModelsResnetBaseFixture, ModelInfer) {
   proteus::NativeClient client;
-  test(&client);
+  const auto& [config, worker] = GetParam();
+  test(&client, config, worker);
 }
+
+INSTANTIATE_TEST_SUITE_P(PerfModelsResnetBase, PerfModelsResnetBaseFixture,
+                         testing::Combine(testing::ValuesIn(configs),
+                                          testing::ValuesIn(workers)));
 
 #ifdef PROTEUS_ENABLE_HTTP
 // @pytest.mark.perf(group="clients")
 // NOLINTNEXTLINE(cert-err58-cpp, cppcoreguidelines-owning-memory)
-TEST_F(HttpFixture, ModelInfer) { test(client_.get()); }
+TEST_P(PerfModelsResnetHttpFixture, ModelInfer) {
+  const auto& [config, worker] = GetParam();
+  test(client_.get(), config, worker);
+}
+
+INSTANTIATE_TEST_SUITE_P(PerfModelsResnetHttp, PerfModelsResnetHttpFixture,
+                         testing::Combine(testing::ValuesIn(configs),
+                                          testing::ValuesIn(workers)));
 #endif

--- a/tests/src/proteus/testing/gtest_fixtures.hpp
+++ b/tests/src/proteus/testing/gtest_fixtures.hpp
@@ -1,4 +1,5 @@
 // Copyright 2022 Xilinx Inc.
+// Copyright 2022 Advanced Micro Devices Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -25,6 +26,10 @@ class BaseFixture : public testing::Test {
   proteus::Server server_;
 };
 
+template <typename T>
+class BaseFixtureWithParams : public BaseFixture,
+                              public testing::WithParamInterface<T> {};
+
 class GrpcFixture : public BaseFixture {
  protected:
   void SetUp() override {
@@ -42,6 +47,10 @@ class GrpcFixture : public BaseFixture {
   bool started_ = false;
 };
 
+template <typename T>
+class GrpcFixtureWithParams : public GrpcFixture,
+                              public testing::WithParamInterface<T> {};
+
 class HttpFixture : public BaseFixture {
  protected:
   void SetUp() override {
@@ -58,6 +67,10 @@ class HttpFixture : public BaseFixture {
   std::unique_ptr<proteus::HttpClient> client_;
   bool started_ = false;
 };
+
+template <typename T>
+class HttpFixtureWithParams : public HttpFixture,
+                              public testing::WithParamInterface<T> {};
 
 #define EXPECT_THROW_CHECK(statement, check, exception) \
   EXPECT_THROW(                                         \

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# Copyright 2021 Xilinx Inc.
+# Copyright 2021 Xilinx, Inc.
+# Copyright 2022 Advanced Micro Devices, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -46,6 +47,7 @@ CAPTURE=""
 BENCHMARK="skip"
 PERF="skip"
 SAVE_BENCHMARK=""
+CPP="all"
 
 root_path=$(realpath "$(dirname "$(realpath "$0")")/..")
 python_tests_path="${root_path}"/tests/
@@ -71,6 +73,7 @@ do
     -k                ) TESTS="$2"       ; shift 2 ;;
     -s                ) CAPTURE="-s"     ; shift 1 ;;
     --build           ) BUILD="$2"       ; shift 2 ;;
+    --cpp             ) CPP="$2"         ; shift 2 ;;
     -h | --help       ) usage            ; exit  0 ;;
     *) break ;;
   esac
@@ -128,11 +131,11 @@ if [[ $MODE == "tests" || $MODE == "all" ]]; then
   cd "$python_tests_path"
   if [[ -n $TESTS ]]; then
     pytest ${testpaths} $CAPTURE -ra --tb=short --hostname $HOSTNAME $PORT $SAVE_BENCHMARK \
-      $FPGAS --benchmark $BENCHMARK --perf $PERF --benchmark-quiet -k "$TESTS"
+      $FPGAS --benchmark $BENCHMARK --perf $PERF --cpp $CPP --benchmark-quiet -k "$TESTS"
     retval=$(($retval | $?))
   else
     pytest ${testpaths} $CAPTURE -ra --tb=short --hostname $HOSTNAME $PORT $SAVE_BENCHMARK \
-      $FPGAS --benchmark $BENCHMARK --perf $PERF --benchmark-quiet
+      $FPGAS --benchmark $BENCHMARK --perf $PERF --cpp $CPP --benchmark-quiet
     retval=$(($retval | $?))
   fi
 

--- a/tests/unit/batching/CMakeLists.txt
+++ b/tests/unit/batching/CMakeLists.txt
@@ -22,7 +22,7 @@ list(
       $<TARGET_OBJECTS:fake_worker_info_buffers_infinite>~predict_api~\
       data_types~$<TARGET_OBJECTS:softBatcher>"
     "$<TARGET_OBJECTS:batcher>~fake_observation~fake_manager~interface~\
-      $<TARGET_OBJECTS:fake_worker_info_buffers_finite>predict_api~data_types~\
+      $<TARGET_OBJECTS:fake_worker_info_buffers_finite>~predict_api~data_types~\
       $<TARGET_OBJECTS:softBatcher>~vector_buffer~buffer~\
       $<TARGET_OBJECTS:native_internal>"
 )

--- a/tests/unit/batching/CMakeLists.txt
+++ b/tests/unit/batching/CMakeLists.txt
@@ -1,4 +1,5 @@
-# Copyright 2021 Xilinx Inc.
+# Copyright 2021 Xilinx, Inc.
+# Copyright 2022 Advanced Micro Devices, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,28 +13,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-include(GoogleTest)
-
-list(APPEND targets test_soft test_soft_batching)
+list(APPEND tests soft soft_batching)
 
 list(
   APPEND
-    targets_libs
-    "$<TARGET_OBJECTS:fake_worker_info_buffers_infinite>~fake_observation~fake_manager~interface~predict_api~data_types~$<TARGET_OBJECTS:softBatcher>"
-    "$<TARGET_OBJECTS:fake_worker_info_buffers_finite>~fake_observation~fake_manager~interface~predict_api~data_types~$<TARGET_OBJECTS:softBatcher>~vector_buffer~buffer~$<TARGET_OBJECTS:native_internal>"
+    tests_libs
+    "$<TARGET_OBJECTS:batcher>~fake_observation~fake_manager~interface~\
+      $<TARGET_OBJECTS:fake_worker_info_buffers_infinite>~predict_api~\
+      data_types~$<TARGET_OBJECTS:softBatcher>"
+    "$<TARGET_OBJECTS:batcher>~fake_observation~fake_manager~interface~\
+      $<TARGET_OBJECTS:fake_worker_info_buffers_finite>predict_api~data_types~\
+      $<TARGET_OBJECTS:softBatcher>~vector_buffer~buffer~\
+      $<TARGET_OBJECTS:native_internal>"
 )
 
-foreach(target lib_str IN ZIP_LISTS targets targets_libs)
-  string(REPLACE "~" ";" libs ${lib_str})
-
-  add_executable(${target} ${target}.cpp)
-  target_include_directories(
-    ${target} BEFORE PRIVATE ${PROTEUS_TEST_INCLUDE_DIRS}
-  )
-  target_include_directories(${target} AFTER PRIVATE ${PROTEUS_INCLUDE_DIRS})
-  target_link_libraries(
-    ${target} $<TARGET_OBJECTS:batcher> ${libs} gtest gtest_main
-  )
-
-  gtest_discover_tests(${target})
-endforeach()
+proteus_add_unit_tests("${tests}" "${tests_libs}")

--- a/tests/unit/buffers/CMakeLists.txt
+++ b/tests/unit/buffers/CMakeLists.txt
@@ -1,4 +1,5 @@
-# Copyright 2021 Xilinx Inc.
+# Copyright 2021 Xilinx, Inc.
+# Copyright 2022 Advanced Micro Devices, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,27 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-include(GoogleTest)
+list(APPEND tests vector_buffer)
 
-list(APPEND targets vector_buffer)
+list(APPEND tests_libs "buffer~data_types~fake_observation~vector_buffer")
 
-foreach(target ${targets})
-  add_executable(test_${target} test_${target}.cpp)
-  target_include_directories(
-    test_${target} BEFORE PRIVATE ${PROTEUS_TEST_INCLUDE_DIRS}
-  )
-  target_include_directories(
-    test_${target} AFTER PRIVATE ${PROTEUS_INCLUDE_DIRS}
-  )
-  target_link_libraries(
-    test_${target}
-    buffer
-    data_types
-    fake_observation
-    ${target}
-    gtest
-    gtest_main
-  )
-
-  gtest_discover_tests(test_${target})
-endforeach()
+proteus_add_unit_tests("${tests}" "${tests_libs}")

--- a/tests/unit/client_operators/CMakeLists.txt
+++ b/tests/unit/client_operators/CMakeLists.txt
@@ -1,4 +1,5 @@
-# Copyright 2022 Xilinx Inc.
+# Copyright 2022 Xilinx, Inc.
+# Copyright 2022 Advanced Micro Devices, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,19 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-include(GoogleTest)
+list(APPEND tests infer_async)
 
-list(APPEND targets infer_async)
-
-foreach(target ${targets})
-  add_executable(test_${target} test_${target}.cpp)
-  target_include_directories(
-    test_${target} BEFORE PRIVATE ${PROTEUS_TEST_INCLUDE_DIRS}
-  )
-  target_include_directories(
-    test_${target} AFTER PRIVATE ${PROTEUS_INCLUDE_DIRS}
-  )
-  target_link_libraries(test_${target} proteus gtest gtest_main)
-
-  gtest_discover_tests(test_${target})
-endforeach()
+proteus_add_system_tests("${tests}")

--- a/tests/unit/core/CMakeLists.txt
+++ b/tests/unit/core/CMakeLists.txt
@@ -1,4 +1,5 @@
-# Copyright 2021 Xilinx Inc.
+# Copyright 2021 Xilinx, Inc.
+# Copyright 2022 Advanced Micro Devices, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,19 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-include(GoogleTest)
+list(APPEND tests inference_request_input request_parameters)
 
-list(APPEND targets inference_request_input request_parameters)
+list(APPEND tests_libs "predict_api" "predict_api")
 
-foreach(target ${targets})
-  add_executable(test_${target} test_${target}.cpp)
-  target_include_directories(
-    test_${target} BEFORE PRIVATE ${PROTEUS_TEST_INCLUDE_DIRS}
-  )
-  target_include_directories(
-    test_${target} AFTER PRIVATE ${PROTEUS_INCLUDE_DIRS}
-  )
-  target_link_libraries(test_${target} predict_api gtest gtest_main)
-
-  gtest_discover_tests(test_${target})
-endforeach()
+proteus_add_unit_tests("${tests}" "${tests_libs}")

--- a/tests/workers/CMakeLists.txt
+++ b/tests/workers/CMakeLists.txt
@@ -1,4 +1,5 @@
-# Copyright 2021 Xilinx Inc.
+# Copyright 2021 Xilinx, Inc.
+# Copyright 2022 Advanced Micro Devices, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,41 +13,37 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-list(APPEND targets echo)
+list(APPEND tests echo)
 
 if(${PROTEUS_ENABLE_VITIS})
-  set(targets ${targets} xmodel)
+  set(tests ${tests} xmodel)
 endif()
 
 if(${PROTEUS_ENABLE_AKS})
-  set(targets ${targets} facedetect)
+  set(tests ${tests} facedetect)
 endif()
 
-foreach(target ${targets})
-  add_executable(test_${target} test_${target}.cpp)
+proteus_add_system_tests("${tests}")
+
+if(${PROTEUS_ENABLE_VITIS})
+  proteus_get_test_target(xmodel_target xmodel)
+  target_link_libraries(${xmodel_target} PRIVATE xir vart-runner)
+endif()
+
+if(${PROTEUS_ENABLE_AKS})
+  proteus_get_test_target(facedetect_target facedetect)
   target_link_libraries(
-    test_${target} PRIVATE proteus Threads::Threads gtest gtest_main
+    ${facedetect_target} PRIVATE opencv_core opencv_imgcodecs
   )
-  target_include_directories(
-    test_${target} PRIVATE ${PROTEUS_PUBLIC_INCLUDE_DIRS}
-  )
-
-  gtest_discover_tests(test_${target})
-endforeach()
-
-if(${PROTEUS_ENABLE_VITIS})
-  target_link_libraries(test_xmodel PRIVATE xir vart-runner)
 endif()
 
-if(${PROTEUS_ENABLE_AKS})
-  target_link_libraries(test_facedetect PRIVATE opencv_core opencv_imgcodecs)
-endif()
-
-foreach(target ${targets})
-  if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${target}.cpp)
-    add_executable(${target} ${target}.cpp)
+foreach(test ${tests})
+  if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${test}.cpp)
+    proteus_get_test_target(target ${test} "exec")
+    proteus_get_test_target(test_target ${test})
+    add_executable(${target} ${test}.cpp)
     target_link_libraries(
-      ${target} PRIVATE $<TARGET_PROPERTY:test_${target},LINK_LIBRARIES>
+      ${target} PRIVATE $<TARGET_PROPERTY:${test_target},LINK_LIBRARIES>
     )
     target_include_directories(${target} PRIVATE ${PROTEUS_PUBLIC_INCLUDE_DIRS})
   endif()

--- a/tests/workers/facedetect.hpp
+++ b/tests/workers/facedetect.hpp
@@ -1,4 +1,5 @@
 // Copyright 2021 Xilinx Inc.
+// Copyright 2022 Advanced Micro Devices Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -43,7 +44,7 @@ void enqueue(std::vector<std::string>& image_paths, int start_index, int count,
              const std::string& workerName, FutureQueue& my_queue) {
   proteus::NativeClient client;
   for (int i = 0; i < count; i++) {
-    auto img = cv::imread(image_paths[start_index + i]);
+    auto img = cv::imread(image_paths[start_index]);
     auto shape = {static_cast<uint64_t>(img.size[0]),
                   static_cast<uint64_t>(img.size[1]),
                   static_cast<uint64_t>(img.channels())};

--- a/tests/workers/test_facedetect.cpp
+++ b/tests/workers/test_facedetect.cpp
@@ -19,7 +19,7 @@
 
 const int gold_response_size = 6;
 const float gold_response_output[gold_response_size] = {
-  -1, 0.9937100410461426, 268, 79.875, 156, 169.06874084472656,
+  -1, 0.9937100410461426, 268, 78.728, 158, 170.800,
 };
 
 std::string prepareDirectory() {

--- a/tests/workers/test_facedetect.py
+++ b/tests/workers/test_facedetect.py
@@ -65,10 +65,10 @@ class TestInferImageFacedetectDPUCADF8H:
         gold_response_output = [
             -1,
             0.9937100410461426,
-            268,
-            79.875,
-            156,
-            169.06874084472656,
+            266,
+            78.728,
+            158,
+            170.800,
         ]
 
         if check_asserts:


### PR DESCRIPTION
# Summary of Changes

*  Support parallelism from HTTP client
*  Update benchmarking script

Closes #65

# Motivation

Allowing parallel requests from HTTP clients allow for higher throughput.

# Implementation

The problem with the HTTP client was in Drogon. We need multiple Drogon clients to allow for making parallel requests. Here, I'm arbitrarily using a 16:1 ratio of clients to EventLoops based on the [question I asked the Drogon developers](https://github.com/drogonframework/drogon/issues/1375). The level of parallelism is exposed at the API level for clients to change the default.

I added a new test to compare the sync and async APIs for making requests to resnet50. There's a problem with the tfzendnn worker that will be a raised as a different issue. The test also exposed a different issue with our test framework because Drogon cannot be restarted in the same process (and [it will not be supported](https://github.com/drogonframework/drogon/issues/1377)). Instead, the HTTP server is started per test suite instead of per test.

The benchmark script hadn't been updated since the Python bindings updates.