### PR TITLE
Add batch size flag to examples

### DIFF
--- a/examples/resnet50/migraphx.py
+++ b/examples/resnet50/migraphx.py
@@ -124,14 +124,13 @@ def load(client, args):
 
     parameters = amdinfer.RequestParameters()
     timeout_ms = 1000  # batcher timeout value in milliseconds
-    batch_size = 2
 
     # Required: specifies path to the model on the server for it to open
     parameters.put("model", args.model)
     # Optional: request a particular batch size to be sent to the backend. The
     # server will attempt to coalesce incoming requests into a single batch of
     # this size and pass it all to the backend.
-    parameters.put("batch", batch_size)
+    parameters.put("batch", args.batch_size)
     # Optional: specifies how long the batcher should wait for more requests before
     # sending the batch on
     parameters.put("timeout", timeout_ms)
@@ -166,6 +165,7 @@ def main(args):
     client = amdinfer.HttpClient(server_addr)
     # start it locally if it doesn't already up if the IP address is the localhost
     if args.ip == "127.0.0.1" and not client.serverLive():
+        print("No server detected. Starting locally...")
         server = amdinfer.Server()
         server.startHttp(args.http_port)
     elif not client.serverLive():

--- a/examples/resnet50/ptzendnn.cpp
+++ b/examples/resnet50/ptzendnn.cpp
@@ -139,6 +139,7 @@ std::string load(const amdinfer::Client* client, const Args& args) {
   parameters.put("model", args.path_to_model);
   parameters.put("input_size", args.input_size);
   parameters.put("output_classes", args.output_classes);
+  parameters.put("batch_size", args.batch_size);
   return client->workerLoad("ptzendnn", &parameters);
 }
 
@@ -172,6 +173,8 @@ int main(int argc, char* argv[]) {
   // +create client
   // ptzendnn.cpp
   amdinfer::NativeClient client;
+
+  std::cout << "Starting server locally...\n";
 
   amdinfer::Server server;
 

--- a/examples/resnet50/ptzendnn.py
+++ b/examples/resnet50/ptzendnn.py
@@ -120,6 +120,7 @@ def load(client, args):
     parameters.put("model", args.model)
     parameters.put("input_size", args.input_size)
     parameters.put("output_classes", args.output_classes)
+    parameters.put("batch_size", args.batch_size)
     endpoint = client.workerLoad("ptzendnn", parameters)
     amdinfer.waitUntilModelReady(client, endpoint)
     return endpoint
@@ -147,6 +148,7 @@ def get_args():
 def main(args):
     print("Running the PT+ZenDNN example for ResNet50 in Python")
 
+    print("Starting server locally")
     server = amdinfer.Server()
     print("Waiting until the server is ready...")
 

--- a/examples/resnet50/resnet.py
+++ b/examples/resnet50/resnet.py
@@ -46,6 +46,12 @@ def parse_args():
     )
 
     parser.add_argument(
+        "--batch-size",
+        default=1,
+        help="Batch size to use for the worker on the server",
+    )
+
+    parser.add_argument(
         "--ip",
         default="127.0.0.1",
         help="IP to use for server",

--- a/examples/resnet50/resnet50.hpp
+++ b/examples/resnet50/resnet50.hpp
@@ -28,6 +28,8 @@ struct Args {
   fs::path path_to_model;
   fs::path path_to_image;
   fs::path path_to_labels;
+  int batch_size = 1;
+  std::string ip = "127.0.0.1";
   uint16_t http_port = 8998;
   uint16_t grpc_port = 50'051;
   int top = 5;
@@ -50,6 +52,10 @@ Args parseArgs(int argc, char** argv) {
       cxxopts::value(args.path_to_image))
     ("labels", "Path to the text file containing the labels on the client",
       cxxopts::value(args.path_to_labels))
+    ("batch-size", "Batch size to use for the worker on the server",
+      cxxopts::value(args.batch_size))
+    ("ip", "IP to use for server",
+      cxxopts::value(args.ip))
     ("http-port", "Port to use for HTTP server",
       cxxopts::value(args.http_port))
     ("grpc-port", "Port to use for gRPC server",

--- a/examples/resnet50/tfzendnn.py
+++ b/examples/resnet50/tfzendnn.py
@@ -117,6 +117,7 @@ def load(client, args):
     parameters.put("output_classes", args.output_classes)
     parameters.put("input_node", args.input_node)
     parameters.put("output_node", args.output_node)
+    parameters.put("batch_size", args.batch_size)
     endpoint = client.workerLoad("tfzendnn", parameters)
     amdinfer.waitUntilModelReady(client, endpoint)
     return endpoint
@@ -156,6 +157,7 @@ def main(args):
     client = amdinfer.GrpcClient(server_addr)
     # start it locally if it doesn't already up if the IP address is the localhost
     if args.ip == "127.0.0.1" and not client.serverLive():
+        print("No server detected. Starting locally...")
         server = amdinfer.Server()
         server.startGrpc(args.grpc_port)
     elif not client.serverLive():

--- a/examples/resnet50/vitis.py
+++ b/examples/resnet50/vitis.py
@@ -120,6 +120,7 @@ def load(client, args):
     # +load
     parameters = amdinfer.RequestParameters()
     parameters.put("model", args.model)
+    parameters.put("batch_size", args.batch_size)
     endpoint = client.workerLoad("xmodel", parameters)
     # -load
     return endpoint

--- a/examples/yolo/migraphx.py
+++ b/examples/yolo/migraphx.py
@@ -114,7 +114,7 @@ def load(client, args):
     # bpickrel: I found that allocation could fail with a large batch value of 64
     # and large (13) default buffer count in the migraphx worker
     # Beyond batch size 56, the worker seems to lock up while compiling the model
-    parameters.put("batch", 2)
+    parameters.put("batch", args.batch_size)
 
     # this call requests the server to either find a running instance of the named
     # worker type, or else create one and initialize it with the parameters.
@@ -193,7 +193,7 @@ def main(args):
 
         image = Image.fromarray(image)
         base_path = pathlib.Path(__file__).parent.resolve()
-        output_name = str(base_path / str(it)) + ".jpg"
+        output_name = str(base_path / f"yolo_output{str(it)}") + ".jpg"
         image.save(output_name)
 
         print("Your marked-up image is at " + str(output_name))

--- a/examples/yolo/yolo.py
+++ b/examples/yolo/yolo.py
@@ -40,6 +40,12 @@ def parse_args():
     )
 
     parser.add_argument(
+        "--batch-size",
+        default=1,
+        help="Batch size to use for the worker on the server",
+    )
+
+    parser.add_argument(
         "--input-size",
         default=416,
         help="Size of the square image in pixels",


### PR DESCRIPTION
# Summary of Changes

*  Add a batch flag to the examples
*  Sync C++ and Python examples
*  Print when starting a local server

Closes #92

# Motivation

These quality-of-life changes improve the examples.

# Implementation

The batch flag is added for both C++ and Python. The two versions of the examples are also synced with each other.
