### PR TITLE
Test build 5 4

### DIFF
--- a/docker/generate.py
+++ b/docker/generate.py
@@ -526,7 +526,8 @@ def install_dev_packages(manager: PackageManager, core):
             {code_indent(manager.clean, 12)}"""
     )
 
-
+# The release repo (Nov 30) is
+# migraphx_apt_repo = 'echo "deb [arch=amd64 trusted=yes] http://repo.radeon.com/rocm/apt/5.4/ ubuntu main" > /etc/apt/sources.list.d/rocm.list' 
 migraphx_apt_repo = 'echo "deb [arch=amd64 trusted=yes] http://repo.radeon.com/rocm/apt/.apt_5.4/ ubuntu main" > /etc/apt/sources.list.d/rocm.list'
 migraphx_yum_repo = '"[ROCm]\\nname=ROCm\\nbaseurl=https://repo.radeon.com/rocm/yum/5.0/\\nenabled=1\\ngpgcheck=1\\ngpgkey=https://repo.radeon.com/rocm/rocm.gpg.key" > /etc/yum.repos.d/rocm.repo'
 

--- a/docker/generate.py
+++ b/docker/generate.py
@@ -365,9 +365,9 @@ def build_optional():
             && rm -rf /tmp/*
 
         # install wrk for http benchmarking
-        RUN wget --quiet https://github.com/wg/wrk/archive/refs/tags/4.1.0.tar.gz \\
-            && tar -xzf 4.1.0.tar.gz \\
-            && cd wrk-4.1.0 \\
+        RUN wget --quiet https://github.com/wg/wrk/archive/refs/tags/4.2.0.tar.gz \\
+            && tar -xzf 4.2.0.tar.gz \\
+            && cd wrk-4.2.0 \\
             && make -j$(($(nproc) - 1)) \\
             && mkdir -p ${COPY_DIR}/usr/local/bin && cp wrk ${COPY_DIR}/usr/local/bin \\
             && rm -rf /tmp/*
@@ -527,7 +527,7 @@ def install_dev_packages(manager: PackageManager, core):
     )
 
 
-migraphx_apt_repo = 'echo "deb [arch=amd64 trusted=yes] http://repo.radeon.com/rocm/apt/5.0/ ubuntu main" > /etc/apt/sources.list.d/rocm.list'
+migraphx_apt_repo = 'echo "deb [arch=amd64 trusted=yes] http://repo.radeon.com/rocm/apt/.apt_5.4/ ubuntu main" > /etc/apt/sources.list.d/rocm.list'
 migraphx_yum_repo = '"[ROCm]\\nname=ROCm\\nbaseurl=https://repo.radeon.com/rocm/yum/5.0/\\nenabled=1\\ngpgcheck=1\\ngpgkey=https://repo.radeon.com/rocm/rocm.gpg.key" > /etc/yum.repos.d/rocm.repo'
 
 
@@ -548,31 +548,17 @@ def build_migraphx(manager: PackageManager):
                 aria2 \\
                 half \\
                 libnuma-dev \\
-                libpython3.6-dev \\
+                libpython3-dev \\
                 miopen-hip-dev \\
                 rocblas-dev \\
                 rocm-cmake \\
                 rocm-dev \\
+                migraphx-dev \\
             && ln -s /opt/rocm-* /opt/rocm \\
             && echo "/opt/rocm/lib" > /etc/ld.so.conf.d/rocm.conf \\
             && echo "/opt/rocm/llvm/lib" > /etc/ld.so.conf.d/rocm-llvm.conf \\
-            && ldconfig \\
-            && pip3 install --no-cache-dir https://github.com/RadeonOpenCompute/rbuild/archive/f74d130aac0405c7e6bc759d331f913a7577bd54.tar.gz \\
-            # clean up
-            {code_indent(manager.clean, 12)}\
-
-        # needed for rbuild
-        ENV LANG=C.UTF-8
-
-        # Install MIGraphX from source
-        RUN mkdir -p /migraphx \\
-            && cd /migraphx && git clone --branch develop https://github.com/ROCmSoftwarePlatform/AMDMIGraphX src \\
-            && cd /migraphx/src  && git checkout cb18b0b5722373c49f5c257380af206e13344735 \\
-            # disable building documentation and tests. Is there a better way?
-            && sed -i 's/^add_subdirectory(doc)/#&/' CMakeLists.txt \\
-            && sed -i 's/^add_subdirectory(test)/#&/' CMakeLists.txt \\
-            && rbuild package -d /migraphx/deps -B /migraphx/build --define "BUILD_TESTING=OFF" \\
-            && cp /migraphx/build/*.{manager.package} ${{COPY_DIR}}"""
+            && ldconfig 
+            """ 
     )
 
 
@@ -599,29 +585,11 @@ def install_migraphx_dev(manager: PackageManager):
                 rocm-device-libs \\
                 rocblas-dev \\
                 libnuma1 \\
+                migraphx-dev \\
             && echo "/opt/rocm/lib" > /etc/ld.so.conf.d/rocm.conf \\
             && echo "/opt/rocm/llvm/lib" > /etc/ld.so.conf.d/rocm-llvm.conf \\
-            && ldconfig \\
-            && {manager.install} \\
-                /*.{manager.package} \\
-            # having symlinks between rocm-* and rocm complicates building the production
-            # image so make /opt/rocm a real directory and move files over to it from
-            # /opt/rocm-* but add a symlink for /opt/rocm-* for compatibility
-            && dir=$(find /opt/ -maxdepth 1 -type d -name "rocm-*") \\
-            && rm -rf /opt/rocm \\
-            && mkdir /opt/rocm \\
-            && rsync -a $dir/* /opt/rocm/ \\
-            && rm -rf $dir \\
-            && ln -s /opt/rocm $dir \\
-            # install .whl from the builder
-            && pip3 install --no-cache-dir /*.whl \\
-            && rm -f /*.whl \\
-            # clean up
-            && {manager.remove} \\
-                python3-pip \\
-                rsync \\
-            {code_indent(manager.clean, 12)} \\
-            && rm -f /*.deb"""
+            && ldconfig 
+            """
     )
 
 
@@ -647,24 +615,11 @@ def install_migraphx_prod(manager: PackageManager):
                 rocm-device-libs \\
                 rocblas-dev \\
                 libnuma1 \\
+                migraphx-dev \\
             && echo "/opt/rocm/lib" > /etc/ld.so.conf.d/rocm.conf \\
             && echo "/opt/rocm/llvm/lib" > /etc/ld.so.conf.d/rocm-llvm.conf \\
-            && ldconfig \\
-            && {manager.install} \\
-                /*.{manager.package} \\
-            # having symlinks between rocm-* and rocm complicates building the production
-            # image so move files over to rocm/ but add a symlink for compatibility
-            && dir=$(find /opt/ -maxdepth 1 -type d -name "rocm-*") \\
-            && rm -rf /opt/rocm \\
-            && mkdir /opt/rocm \\
-            && rsync -a $dir/* /opt/rocm/ \\
-            && rm -rf $dir \\
-            && ln -s /opt/rocm $dir \\
-            # clean up
-            && {manager.remove} \\
-                rsync \\
-            {code_indent(manager.clean, 12)} \\
-            && rm -f /*.{manager.package}"""
+            && ldconfig 
+            """ 
     )
 
 
@@ -809,7 +764,7 @@ def get_parser():
     command_group.add_argument(
         "--base-image",
         action="store",
-        default="ubuntu:18.04",
+        default="ubuntu:20.04",
         help="base image to use",
     )
     command_group.add_argument(

--- a/docker/generate.py
+++ b/docker/generate.py
@@ -526,10 +526,8 @@ def install_dev_packages(manager: PackageManager, core):
             {code_indent(manager.clean, 12)}"""
     )
 
-# The release repo (Nov 30) is
-# migraphx_apt_repo = 'echo "deb [arch=amd64 trusted=yes] http://repo.radeon.com/rocm/apt/5.4/ ubuntu main" > /etc/apt/sources.list.d/rocm.list' 
-migraphx_apt_repo = 'echo "deb [arch=amd64 trusted=yes] http://repo.radeon.com/rocm/apt/.apt_5.4/ ubuntu main" > /etc/apt/sources.list.d/rocm.list'
-migraphx_yum_repo = '"[ROCm]\\nname=ROCm\\nbaseurl=https://repo.radeon.com/rocm/yum/5.0/\\nenabled=1\\ngpgcheck=1\\ngpgkey=https://repo.radeon.com/rocm/rocm.gpg.key" > /etc/yum.repos.d/rocm.repo'
+migraphx_apt_repo = 'echo "deb [arch=amd64 trusted=yes] http://repo.radeon.com/rocm/apt/5.4/ ubuntu main" > /etc/apt/sources.list.d/rocm.list' 
+migraphx_yum_repo = '"[ROCm]\\nname=ROCm\\nbaseurl=https://repo.radeon.com/rocm/yum/5.4/\\nenabled=1\\ngpgcheck=1\\ngpgkey=https://repo.radeon.com/rocm/rocm.gpg.key" > /etc/yum.repos.d/rocm.repo'
 
 
 def build_migraphx(manager: PackageManager):


### PR DESCRIPTION
# Summary of Changes

*  Update to generate.py, to use rocm 5.4 and to install rocm (including migraphx) from repository instead of building migraphx from source code.  This is a merge of sample changes made by Chris Austen, with the current main branch.  


### Changes:
- changes URLs of apt and yum repositories for rocm
- functions build_migraphx, install_migraphx_dev and install_migraphx_prod have been largely disabled by removing the code that performs builds.  What's left just installs from repository with apt or yum.  These functions can probably be merged if it can be kept compatible with the Python structure.
- Ubuntu version is reset from 18.04 to 20.04  I'm not sure which is correct.
- The changes were originally set to test the prerelease rocm version at [http://repo.radeon.com/rocm/apt/.apt_5.4/](http://repo.radeon.com/rocm/apt/.apt_5.4/)   .  Since then, the public release at [http://repo.radeon.com/rocm/apt/.apt_5.4/](http://repo.radeon.com/rocm/apt/5.4/) was made.  The latter is included here but commented out.

### Does it work?

1. The change was shown to work on server rocm-rome-6.amd.com with the .apt_5.4 repository.  I tested with the three migraphx scripts.
2. The change does not work on Brian's home tower.  The symptom is that within the Docker container, the user home directory is owned by root, not the user (use `ls -l /home` to see  this).  The command line used to start Docker was `./amdinfer run --dev --group-add video   --network=host`  With this ownership problem, the server can't be built so it can't be tested.  This problem was thought to have to do with needing to give the user access to group video, but adding the command line switch `--group-add video` did not help.
3. The Docker change works, but rocm doesn't work,  on server rocm-rome-6.amd.com with the [http://repo.radeon.com/rocm/apt/.apt_5.4/](http://repo.radeon.com/rocm/apt/5.4/) repository.  The docker image runs and the server can be built, but when I tested the Resnet50 script I got the following errors:
`amdinfer-dev:amdinfer$ amdinfer start
gRPC server starting at port 50051
HTTP server starting at port 8998
MIOpen(HIP): Error [Compile] 'hiprtcCompileProgram(prog.get(), c_options.size(), c_options.data())' static_kernel_gridwise_convolution_forward_implicit_gemm_v4r4_xdlops_nchw_kcyx_nkhw_padded_gemm.cpp: HIPRTC_ERROR_COMPILATION (6)
MIOpen(HIP): Error [BuildHip] HIPRTC status = HIPRTC_ERROR_COMPILATION (6), source file: static_kernel_gridwise_convolution_forward_implicit_gemm_v4r4_xdlops_nchw_kcyx_nkhw_padded_gemm.cpp
MIOpen(HIP): Warning [BuildHip] /tmp/comgr-396113/input/static_kernel_gridwise_convolution_forward_implicit_gemm_v4r4_xdlops_nchw_kcyx_nkhw_padded_gemm.cpp:7:15: error: unknown type name 'FLOAT'
        const FLOAT* const __restrict__ p_in_global,
              ^
/tmp/comgr-396113/input/static_kernel_gridwise_convolution_forward_implicit_gemm_v4r4_xdlops_nchw_kcyx_nkhw_padded_gemm.cpp:8:15: error: unknown type name 'FLOAT'
        const FLOAT* const __restrict__ p_wei_global,
              ^
/tmp/comgr-396113/input/static_kernel_gridwise_convolution_forward_implicit_gemm_v4r4_xdlops_nchw_kcyx_nkhw_padded_gemm.cpp:9:9: error: unknown type name 'FLOAT'
        FLOAT* const __restrict__ p_out_global)
        ^
/tmp/comgr-396113/input/static_kernel_gridwise_convolution_forward_implicit_gemm_v4r4_xdlops_nchw_kcyx_nkhw_padded_gemm.cpp:149:13: error: use of undeclared identifier 'FLOAT'
            FLOAT,       // Input data type
            ^
4 errors generated when compiling for gfx908.
MIOpen Error: /long_pathname_so_that_rpms_can_package_the_debug_info/data/driver/MLOpen/src/hipoc/hipoc_program.cpp:304: Code object build failed. Source: static_kernel_gridwise_convolution_forward_implicit_gemm_v4r4_xdlops_nchw_kcyx_nkhw_padded_gemm.cpp
MIGraphX Error: /long_pathname_so_that_rpms_can_package_the_debug_info/data/driver/AMDMIGraphX/src/targets/gpu/convolution.cpp:83: compute: MIOpen Convolution: running convolution using find_2.0 failed
[amdinfer] [error] Failed to call function`

The machine rocm-rome-6 runs Ubuntu 18.04.  My tower runs Ubuntu 20.04.


[generate.txt](https://github.com/Xilinx/inference-server/files/10145033/generate.txt)
