### PR TITLE
Bump OS to Ubuntu 20.04

### DIFF
--- a/docker/get_dynamic_dependencies.sh
+++ b/docker/get_dynamic_dependencies.sh
@@ -51,17 +51,25 @@ save_data() {
 resolve_symlinks() {
   dep=$1
 
-  dir=$(dirname $dep)
-  while [[ -L $dep ]]; do
-    save_data "$(realpath -s $dep)"
-    dep=$(readlink $dep)
+  # resolve all the symlinks in the directory
+  dir=$(readlink -f $(dirname $dep))
+  base=$(basename $dep)
+
+  new_dep="$dir/$base"
+  while [[ -L $new_dep ]]; do
+    save_data "$(realpath -s $new_dep)"
+    new_dep=$(readlink $new_dep)
     # if the next path isn't absolute, append the directory from above and
     # resolve full path
-    if [[ ! "$dep" = /* ]]; then
-      dep="$dir/$dep"
+    if [[ ! "$new_dep" = /* ]]; then
+      new_dep="$dir/$new_dep"
+    else
+      dir=$(readlink -f $(dirname $new_dep))
+      base=$(basename $new_dep)
+      new_dep="$dir/$base"
     fi
   done
-  save_data "$(realpath -s $dep)"
+  save_data "$(realpath -s $new_dep)"
 }
 
 # Usage: get_dependencies /path/to/file

--- a/docker/template.dockerfile
+++ b/docker/template.dockerfile
@@ -89,10 +89,10 @@ $[INSTALL_BUILD_PACKAGES]
 # install extra optional distro packages
 $[INSTALL_OPTIONAL_BUILD_PACKAGES]
 
-# install Boost for VAI
-RUN wget --quiet https://boostorg.jfrog.io/artifactory/main/release/1.65.1/source/boost_1_65_1.tar.gz \
-    && tar -xzf boost_1_65_1.tar.gz \
-    && cd boost_1_65_1 \
+# install Boost for VAI and Apache Thrift. This must match the boost version installed by XRT package
+RUN wget --quiet https://boostorg.jfrog.io/artifactory/main/release/1.71.0/source/boost_1_71_0.tar.gz \
+    && tar -xzf boost_1_71_0.tar.gz \
+    && cd boost_1_71_0 \
     # && PYTHON_ROOT=$(dirname $(find /usr/include -name pyconfig.h)) \
     # && ./bootstrap.sh --with-python=/usr/bin/python3 --with-python-root=${PYTHON_ROOT} \
     && INSTALL_DIR=/tmp/installed \
@@ -502,6 +502,8 @@ RUN git clone --recursive --single-branch --branch v2.5 --depth 1 https://github
     && cd ./build && cat install_manifest.txt | xargs -i bash -c "if [ -f {} ]; then cp --parents -P {} ${COPY_DIR}; fi" \
     && cat install_manifest.txt > ${MANIFESTS_DIR}/vart.txt \
     && cd ${VITIS_ROOT}/rt-engine \
+    # find the required components. Adding this was needed when using Boost from Ubuntu apt repositories
+    && sed -i '42i find_package(Boost COMPONENTS system filesystem thread serialization)' ./CMakeLists.txt \
     && ./cmake.sh --clean --build-dir=./build --type=release --cmake-options="-DXRM_DIR=/opt/xilinx/xrm/share/cmake" --cmake-options="-DBUILD_TESTS=OFF" --install-prefix /usr/local/ \
     && cd ./build && cat install_manifest.txt | xargs -i bash -c "if [ -f {} ]; then cp --parents -P {} ${COPY_DIR}; fi" \
     && cat install_manifest.txt > ${MANIFESTS_DIR}/rt-engine.txt \

--- a/external/aks/reference/kernel_src/classification_accuracy/CMakeLists.txt
+++ b/external/aks/reference/kernel_src/classification_accuracy/CMakeLists.txt
@@ -34,9 +34,9 @@ message(STATUS "AKS Includes: ${aks_INCLUDE_DIRS}")
 
 execute_process(COMMAND uname -m OUTPUT_VARIABLE arch)
 if(${arch} MATCHES ".*x86.*")
-  find_package(Boost 1.65.1 EXACT REQUIRED COMPONENTS system filesystem)
+  find_package(Boost EXACT REQUIRED COMPONENTS system filesystem)
 else()
-  find_package(Boost 1.65.1 REQUIRED COMPONENTS system filesystem)
+  find_package(Boost REQUIRED COMPONENTS system filesystem)
 endif()
 
 add_library(${PROJECT_NAME} SHARED AksClassificationAccuracy.cpp)

--- a/external/aks/reference/kernel_src/save_boxes_darknet_facedetect/CMakeLists.txt
+++ b/external/aks/reference/kernel_src/save_boxes_darknet_facedetect/CMakeLists.txt
@@ -33,9 +33,9 @@ message(STATUS "AKS Includes: ${aks_INCLUDE_DIRS}")
 
 execute_process(COMMAND uname -m OUTPUT_VARIABLE arch)
 if(${arch} MATCHES ".*x86.*")
-  find_package(Boost 1.65.1 EXACT REQUIRED COMPONENTS system filesystem)
+  find_package(Boost EXACT REQUIRED COMPONENTS system filesystem)
 else()
-  find_package(Boost 1.65.1 REQUIRED COMPONENTS system filesystem)
+  find_package(Boost REQUIRED COMPONENTS system filesystem)
 endif()
 
 add_library(${PROJECT_NAME} SHARED AksSaveBoxesDarknetFacedetect.cpp)

--- a/external/aks/reference/kernel_src/save_boxes_darknet_format/CMakeLists.txt
+++ b/external/aks/reference/kernel_src/save_boxes_darknet_format/CMakeLists.txt
@@ -35,9 +35,9 @@ find_package(OpenCV REQUIRED COMPONENTS core imgproc imgcodecs)
 
 execute_process(COMMAND uname -m OUTPUT_VARIABLE arch)
 if(${arch} MATCHES ".*x86.*")
-  find_package(Boost 1.65.1 EXACT REQUIRED COMPONENTS system filesystem)
+  find_package(Boost EXACT REQUIRED COMPONENTS system filesystem)
 else()
-  find_package(Boost 1.65.1 REQUIRED COMPONENTS system filesystem)
+  find_package(Boost REQUIRED COMPONENTS system filesystem)
 endif()
 
 add_library(${PROJECT_NAME} SHARED AksSaveBoxesDarknetFormat.cpp)


### PR DESCRIPTION
# Summary of Changes

*  Change the default base OS of the Docker image from Ubuntu 18.04 to Ubuntu 20.04

# Motivation

Ubuntu 18.04 enters EOL in 2023 and a newer operating system allows for improved security and updated system packages.

# Implementation

The version is bumped up in the Dockerfile generation script. This change required a few minor updates as well:
- changing the Boost version
- removing the fixed Boost version in some AKS CMakeLists.txt files
- adding site-packages to Python's path
