### PR TITLE
Document the public API

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -49,13 +49,13 @@ for dir in /workspace/*; do  # lists the absolute path to the file/directory
   # if they don't match, adjust
   if [ -n "$USER_GID" ] && [ "$USER_GID" != "$CUR_GID" ]; then
     groupmod -g "${USER_GID}" amdinfer
-    chown -R --silent :amdinfer /home/amdinfer-user
   fi
+  chown -R --silent :amdinfer /home/amdinfer-user
   if [ -n "$USER_UID" ] && [ "$USER_UID" != "$CUR_UID" ]; then
     usermod -u "${USER_UID}" amdinfer-user
-    # fix other permissions
-    chown -R --silent amdinfer-user /home/amdinfer-user
   fi
+  # fix other permissions
+  chown -R --silent amdinfer-user /home/amdinfer-user
 
   break
 done

--- a/docker/generate.py
+++ b/docker/generate.py
@@ -572,8 +572,6 @@ def install_python_packages():
                 # install these first
                 setuptools \\
                 wheel \\
-                # the sphinx theme has a bug with docutils>=0.17
-                "docutils<0.17" \\
             # clang-tidy-10 installs pyyaml which can't be uninstalled with pip
             && pip install --no-cache-dir --ignore-installed \\
                 # install testing dependencies
@@ -591,6 +589,7 @@ def install_python_packages():
                 sphinx-issues \\
                 exhale \\
                 sphinx-tabs \\
+                sphinxcontrib-openapi \\
                 # install linting tools
                 black \\
                 cpplint \\

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -81,8 +81,8 @@ exhale_args = {
     # Suggested optional arguments
     "createTreeView": True,
     # TIP: if using the sphinx-bootstrap-theme, you need
-    "treeViewIsBootstrap": True,
-    "unabridgedOrphanKinds": {"define", "dir", "typedef", "variable"},
+    # "treeViewIsBootstrap": True,
+    "unabridgedOrphanKinds": {"define", "dir", "typedef", "variable", "file"},
     # exclude PIMPL classes
     "listingExclude": [r".*Impl$"],
 }
@@ -100,7 +100,6 @@ confluence_server_url = "https://confluence.xilinx.com/"
 autodoc_default_options = {
     "members": True,
     "special-members": "__init__",
-    "undoc-members": True,
 }
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -36,11 +36,13 @@ project = "AMD Inference Server"
 copyright = "2022 Advanced Micro Devices, Inc."
 author = "Advanced Micro Devices, Inc."
 
-with open(os.path.abspath("../VERSION")) as f:
-    raw_version = f.read().strip()
-
+# override this value to build different versions
 version = "main"
-release = f"v{raw_version}"
+
+if version != "main":
+    release = f"v{version}"
+else:
+    release = version
 
 # -- General configuration ---------------------------------------------------
 
@@ -126,6 +128,14 @@ autosectionlabel_maxdepth = 2
 
 # sphinx.ext.extlinks configuration. syntax is key: (url, caption). The key should not have underscores.
 extlinks = {
+    "amdinfertree": (
+        f"https://github.com/Xilinx/inference-server/tree/{release}/%s",
+        "%s",
+    ),
+    "amdinferblob": (
+        f"https://github.com/Xilinx/inference-server/blob/{release}/%s",
+        "%s",
+    ),
     "ubuntupackages": ("https://packages.ubuntu.com/bionic/%s", "%s"),
     "pypipackages": ("https://pypi.org/project/%s", "%s"),
     "github": ("https://github.com/%s", "%s"),
@@ -149,7 +159,7 @@ numfig = True
 
 # Configure 'Edit on GitHub' extension
 edit_on_github_project = "Xilinx/inference-server"
-edit_on_github_branch = "main/docs"
+edit_on_github_branch = f"{release}/docs"
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]
@@ -191,7 +201,7 @@ if os.path.exists("./_themes/xilinx"):
 
     html_context["languages"] = [("en", "/" + "inference-server/" + version + "/")]
 
-    versions = ["0.1.0", "0.2.0"]
+    versions = ["0.1.0", "0.2.0", "0.3.0"]
     versions.append("main")
     html_context["versions"] = []
     for version in versions:

--- a/docs/cpp_user_api.rst
+++ b/docs/cpp_user_api.rst
@@ -20,13 +20,22 @@ C++
 Clients
 -------
 
+.. doxygenfunction:: amdinfer::serverHasExtension
+
+.. doxygenfunction:: amdinfer::waitUntilServerReady
+
+.. doxygenfunction:: amdinfer::waitUntilModelReady
+
+.. doxygenfunction:: amdinfer::inferAsyncOrdered
+
+.. doxygenfunction:: amdinfer::inferAsyncOrderedBatched
+
 gRPC
 ^^^^
 
 .. _user_cpp_clients_grpc:
 .. doxygenclass:: amdinfer::GrpcClient
     :members:
-    :undoc-members:
 
 HTTP
 ^^^^
@@ -34,7 +43,6 @@ HTTP
 .. _user_cpp_clients_http:
 .. doxygenclass:: amdinfer::HttpClient
     :members:
-    :undoc-members:
 
 
 Native
@@ -43,7 +51,6 @@ Native
 .. _user_cpp_clients_native:
 .. doxygenclass:: amdinfer::NativeClient
     :members:
-    :undoc-members:
 
 WebSocket
 ^^^^^^^^^
@@ -51,7 +58,6 @@ WebSocket
 .. _user_cpp_clients_websocket:
 .. doxygenclass:: amdinfer::WebSocketClient
     :members:
-    :undoc-members:
 
 Core
 ----
@@ -62,7 +68,6 @@ DataType
 .. _user_cpp_core_datatype:
 .. doxygenclass:: amdinfer::DataType
     :members:
-    :undoc-members:
 
 Exceptions
 ^^^^^^^^^^
@@ -76,42 +81,34 @@ Prediction
 .. _user_cpp_core_request_parameters:
 .. doxygenclass:: amdinfer::RequestParameters
     :members:
-    :undoc-members:
 
 .. _user_cpp_core_server_metadata:
 .. doxygenstruct:: amdinfer::ServerMetadata
     :members:
-    :undoc-members:
 
 .. _user_cpp_core_inference_request_input:
 .. doxygenclass:: amdinfer::InferenceRequestInput
     :members:
-    :undoc-members:
 
 .. _user_cpp_core_inference_request_output:
 .. doxygenclass:: amdinfer::InferenceRequestOutput
     :members:
-    :undoc-members:
 
 .. _user_cpp_core_inference_response:
 .. doxygenclass:: amdinfer::InferenceResponse
     :members:
-    :undoc-members:
 
 .. _user_cpp_core_inference_request:
 .. doxygenclass:: amdinfer::InferenceRequest
     :members:
-    :undoc-members:
 
 .. _user_cpp_core_inference_model_metadata_tensor:
 .. doxygenclass:: amdinfer::ModelMetadataTensor
     :members:
-    :undoc-members:
 
 .. _user_cpp_core_inference_model_metadata:
 .. doxygenclass:: amdinfer::ModelMetadata
     :members:
-    :undoc-members:
 
 Servers
 -------
@@ -119,4 +116,3 @@ Servers
 .. _user_cpp_servers_server:
 .. doxygenclass:: amdinfer::Server
     :members:
-    :undoc-members:

--- a/docs/example_resnet50_cpp.rst
+++ b/docs/example_resnet50_cpp.rst
@@ -18,7 +18,7 @@ Running ResNet50 - C++
 
 This page walks you through the C++ versions of the ResNet50 examples.
 These examples are intended to run in the dev container because you need to build and compile these executables.
-You can see the full source files used here in the `repository <https://github.com/Xilinx/inference-server/tree/main/examples/resnet50>`__ for more details.
+You can see the full source files used here in the :amdinfertree:`repository <examples/resnet50>` for more details.
 
 The inference server binds its C++ API to Python so the Python usage and functions look similar to their C++ counterparts but there are some differences due to the available features in both languages.
 You should read the :ref:`Python version of this example <example_resnet50_python:Running ResNet50 - Python` to better compare these two.

--- a/docs/example_resnet50_cpp.rst
+++ b/docs/example_resnet50_cpp.rst
@@ -20,7 +20,8 @@ This page walks you through the C++ versions of the ResNet50 examples.
 These examples are intended to run in the dev container because you need to build and compile these executables.
 You can see the full source files used here in the `repository <https://github.com/Xilinx/inference-server/tree/main/examples/resnet50>`__ for more details.
 
-While the inference server supports many backends, client applications to make requests to any of them largely look the same.
+The inference server binds its C++ API to Python so the Python usage and functions look similar to their C++ counterparts but there are some differences due to the available features in both languages.
+You should read the :ref:`Python version of this example <example_resnet50_python:Running ResNet50 - Python` to better compare these two.
 
 .. note::
     These examples are intended to demonstrate the API and how to communicate with the server.

--- a/docs/example_resnet50_python.rst
+++ b/docs/example_resnet50_python.rst
@@ -18,7 +18,7 @@ Running ResNet50 - Python
 
 This page walks you through the Python versions of the ResNet50 examples.
 These examples and script are intended to run in the development container.
-You can see the full source files in the `repository <https://github.com/Xilinx/inference-server/tree/main/examples/resnet50>`__ for more details.
+You can see the full source files in the :amdinfertree:`repository <examples/resnet50>` for more details.
 
 The inference server binds its C++ API to Python so the Python usage and functions look similar to their C++ counterparts but there are some differences due to the available features in both languages.
 You should read the :ref:`C++ version of this example <example_resnet50_cpp:Running ResNet50 - C++` to better compare these two.

--- a/docs/example_resnet50_python.rst
+++ b/docs/example_resnet50_python.rst
@@ -17,11 +17,11 @@ Running ResNet50 - Python
 =========================
 
 This page walks you through the Python versions of the ResNet50 examples.
-These examples and script are intended to run in the dev container.
+These examples and script are intended to run in the development container.
 You can see the full source files in the `repository <https://github.com/Xilinx/inference-server/tree/main/examples/resnet50>`__ for more details.
 
 The inference server binds its C++ API to Python so the Python usage and functions look similar to their C++ counterparts but there are some differences due to the available features in both languages.
-You should read the C++ version of this documentation to better compare these two.
+You should read the :ref:`C++ version of this example <example_resnet50_cpp:Running ResNet50 - C++` to better compare these two.
 
 In the dev container, the Python library is automatically built and installed as part of the CMake build process.
 You may also install the Python library by installing a wheel.

--- a/docs/hello_world_echo.rst
+++ b/docs/hello_world_echo.rst
@@ -22,7 +22,7 @@ Hello World - Python
 AMD Inference Server's Python API allows you to start the server and send requests to it from Python.
 This example walks you through how to start the server and use Python to send requests to a simple model.
 This example and script are intended to run in the dev container.
-The complete script used here is available in the `repository <https://github.com/Xilinx/inference-server/tree/main/examples/hello_world>`__.
+The complete script used here is available in the :amdinfertree:`repository <examples/hello_world>`.
 
 Import the library
 ------------------

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -59,4 +59,4 @@ You can also raise issues on the `Github page <https://github.com/Xilinx/inferen
 
 The AMD Inference Server is open-source and welcomes contributions.
 If you are interested in adding a feature, raise an issue first so your proposal can be discussed.
-Follow the `Contributing <https://xilinx.github.io/inference-server/main/contributing.html>`__ guidelines when making a new pull request.
+Follow the :ref:`Contributing <contributing:Contributing>` guidelines when making a new pull request.

--- a/docs/kserve.rst
+++ b/docs/kserve.rst
@@ -270,7 +270,7 @@ This use case may be needed if your cluster doesn't have a load-balancer and/or 
 
 Once you can communicate with your service, you can make requests to the Inference Server using REST with cURL or the `KServe Python API <https://kserve.github.io/website/0.8/sdk_docs/sdk_doc/>`__.
 The request will be routed to the server and the response will be returned.
-You can see some examples of using the KServe Python API to make requests in the `tests <https://github.com/Xilinx/inference-server/tree/main/tests/kserve>`__.
+You can see some examples of using the KServe Python API to make requests in the :amdinfertree:`tests <tests/kserve>`.
 
 Debugging
 ---------

--- a/docs/python.rst
+++ b/docs/python.rst
@@ -72,3 +72,4 @@ API
 
 .. automodule:: amdinfer
     :imported-members:
+    :undoc-members:

--- a/docs/quickstart_inference.rst
+++ b/docs/quickstart_inference.rst
@@ -133,4 +133,4 @@ Making requests directly
 
 If you are unable to use the library, you can also communicate with the server directly over REST or gRPC.
 However, you will need to construct the requests yourself in the correct format.
-Both the :ref:`REST API <rest:rest endpoints>` and the `gRPC API <https://github.com/Xilinx/inference-server/blob/main/src/amdinfer/core/predict_api.proto>`__ are documented.
+Both the :ref:`REST API <rest:rest endpoints>` and the :amdinferblob:`gRPC API <src/amdinfer/core/predict_api.proto>` are documented.

--- a/docs/rest.rst
+++ b/docs/rest.rst
@@ -19,7 +19,7 @@ REST Endpoints
 
 The REST endpoints are based on `KServe's v2 specification <https://github.com/kserve/kserve/blob/master/docs/predict-api/v2/required_api.md>`__.
 Additional endpoints are driven by community adoption.
-The `full OpenAPI 3.0 spec <https://github.com/Xilinx/inference-server/blob/main/docs/rest_api.yaml>`__ is available in the repository.
+The :amdinferblob:`full OpenAPI 3.0 spec <docs/rest_api.yaml>` is available in the repository.
 
 .. openapi:httpdomain:: rest_api.yaml
     :generate-examples-from-schemas:

--- a/examples/yolo/yolo_image_processing.py
+++ b/examples/yolo/yolo_image_processing.py
@@ -89,7 +89,7 @@ def postprocess_bbbox(pred_bbox, ANCHORS, STRIDES, XYSCALE=[1, 1, 1]):
         xy_grid = np.expand_dims(np.stack(xy_grid, axis=-1), axis=2)
 
         xy_grid = np.tile(np.expand_dims(xy_grid, axis=0), [1, 1, 1, 3, 1])
-        xy_grid = xy_grid.astype(np.float)
+        xy_grid = xy_grid.astype(np.float32)
 
         pred_xy = (
             (special.expit(conv_raw_dxdy) * XYSCALE[i])

--- a/include/amdinfer/clients/client.hpp
+++ b/include/amdinfer/clients/client.hpp
@@ -28,43 +28,177 @@
 
 namespace amdinfer {
 
+/**
+ * @brief The base Client class defines the set of methods that all client
+ * implementations must provide. These methods are based on the API defined by
+ * KServe, with some extensions. This is a pure virtual class.
+ */
 class Client {
  public:
+  /// Destructor
   virtual ~Client() = default;
 
+  /**
+   * @brief Returns the server metadata as a ServerMetadata object
+   *
+   * @return ServerMetadata
+   */
   virtual ServerMetadata serverMetadata() const = 0;
+  /**
+   * @brief Checks if the server is live
+   *
+   * @return bool - true if server is live, false otherwise
+   */
   virtual bool serverLive() const = 0;
+  /**
+   * @brief Checks if the server is ready
+   *
+   * @return bool - true if server is ready, false otherwise
+   */
   virtual bool serverReady() const = 0;
+  /**
+   * @brief Checks if a model/worker is ready
+   *
+   * @param model name of the model to check
+   * @return bool - true if model is ready, false otherwise
+   */
   virtual bool modelReady(const std::string& model) const = 0;
+  /**
+   * @brief Returns the metadata associated with a ready model/worker
+   *
+   * @param model name of the model/worker to get metadata
+   * @return ModelMetadata
+   */
   virtual ModelMetadata modelMetadata(const std::string& model) const = 0;
 
+  /**
+   * @brief Loads a model with the given name and load-time parameters. This
+   * method assumes that a directory with this model name already exists in the
+   * model repository directory for the server containing the model and its
+   * metadata in the right format.
+   *
+   * @param model name of the model to load from the model repository directory
+   * @param parameters load-time parameters for the worker supporting the model
+   */
   virtual void modelLoad(const std::string& model,
                          RequestParameters* parameters) const = 0;
+  /**
+   * @brief Unloads a previously loaded model and shut it down. This is
+   * identical in functionality to workerUnload and is provided for symmetry.
+   *
+   * @param model name of the model to unload
+   */
   virtual void modelUnload(const std::string& model) const = 0;
 
+  /**
+   * @brief Makes a synchronous inference request to the given model/worker. The
+   * contents of the request depends on the model/worker that the request is
+   * for.
+   *
+   * @param model name of the model/worker to request inference to
+   * @param request the request
+   * @return InferenceResponse
+   */
   virtual InferenceResponse modelInfer(
     const std::string& model, const InferenceRequest& request) const = 0;
+  /**
+   * @brief Makes an asynchronous inference request to the given model/worker.
+   * The contents of the request depends on the model/worker that the request
+   * is for. The user must save the Future object and use it to get the results
+   * of the inference later.
+   *
+   * @param model name of the model/worker to request inference to
+   * @param request the request
+   * @return InferenceResponseFuture
+   */
   virtual InferenceResponseFuture modelInferAsync(
     const std::string& model, const InferenceRequest& request) const = 0;
+  /**
+   * @brief Gets a list of active models on the server, returning their names
+   *
+   * @return std::vector<std::string>
+   */
   virtual std::vector<std::string> modelList() const = 0;
 
+  /**
+   * @brief Loads a worker with the given name and load-time parameters.
+   *
+   * @param worker name of the worker to load
+   * @param parameters load-time parameters for the worker
+   * @return std::string
+   */
   virtual std::string workerLoad(const std::string& worker,
                                  RequestParameters* parameters) const = 0;
+  /**
+   * @brief Unloads a previously loaded worker and shut it down. This is
+   * identical in functionality to modelUnload and is provided for symmetry.
+   *
+   * @param worker name of the worker to unload
+   */
   virtual void workerUnload(const std::string& worker) const = 0;
 
+  /**
+   * @brief Checks if the server has the requested number of a specific hardware
+   * device
+   *
+   * @param name name of the hardware device to check
+   * @param num number of the device that should exist at minimum
+   * @return bool - true if server has at least the requested number of the
+   * hardware device, false otherwise
+   */
   virtual bool hasHardware(const std::string& name, int num) const = 0;
 
  protected:
   Client();
 };
 
+/**
+ * @brief Checks if the server has a certain extension
+ *
+ * @param client a pointer to a client object
+ * @param extension name of the extension to check on the server
+ * @return bool - true if the server has the requested extension
+ */
 bool serverHasExtension(const Client* client, const std::string& extension);
+/**
+ * @brief Blocks until the server is ready
+ *
+ * @param client a pointer to a client object
+ */
 void waitUntilServerReady(const Client* client);
+/**
+ * @brief Blocks until the named model/worker is ready
+ *
+ * @param client a pointer to a client object
+ * @param model the model/worker to wait for
+ */
 void waitUntilModelReady(const Client* client, const std::string& model);
 
+/**
+ * @brief Makes inference requests in parallel to the specified model. All
+ * requests are sent in parallel and the responses are gathered and returned in
+ * the same order.
+ *
+ * @param client a pointer to a client object
+ * @param model the model/worker to make inference requests to
+ * @param requests a vector of requests
+ * @return std::vector<InferenceResponse>
+ */
 std::vector<InferenceResponse> inferAsyncOrdered(
   Client* client, const std::string& model,
   const std::vector<InferenceRequest>& requests);
+/**
+ * @brief Makes inference requests in parallel to the specified model in
+ * batches. Each batch of requests are gathered and the responses are added to a
+ * vector. Once all the responses are received, the response vector is returned.
+ *
+ * @param client a pointer to a client object
+ * @param model the model/worker to make inference requests to
+ * @param requests a vector of requests
+ * @param batch_size the number of requests that should be sent in parallel at
+ * once
+ * @return std::vector<InferenceResponse>
+ */
 std::vector<InferenceResponse> inferAsyncOrderedBatched(
   Client* client, const std::string& model,
   const std::vector<InferenceRequest>& requests, size_t batch_size);

--- a/include/amdinfer/clients/grpc.hpp
+++ b/include/amdinfer/clients/grpc.hpp
@@ -34,36 +34,142 @@ class Channel;
 
 namespace amdinfer {
 
+/**
+ * @brief The GrpcClient class implements the Client using gRPC
+ *
+ * @details Usage:
+ *
+ * GrpcClient client{"127:0.0.1:50051"};
+ * if (client.serverLive()){
+ *   ...
+ * }
+ *
+ */
 class GrpcClient : public Client {
  public:
+  /**
+   * @brief Constructs a new GrpcClient object
+   *
+   * @param address Address of the server to connect to
+   */
   explicit GrpcClient(const std::string& address);
+  /**
+   * @brief Constructs a new GrpcClient object
+   *
+   * @param channel an existing gRPC channel to reuse to connect to the server
+   */
   explicit GrpcClient(const std::shared_ptr<::grpc::Channel>& channel);
+  /// Destructor
   ~GrpcClient() override;
 
+  /**
+   * @brief Returns the server metadata as a ServerMetadata object
+   *
+   * @return ServerMetadata
+   */
   ServerMetadata serverMetadata() const override;
+  /**
+   * @brief Checks if the server is live
+   *
+   * @return bool - true if server is live, false otherwise
+   */
   bool serverLive() const override;
+  /**
+   * @brief Checks if the server is ready
+   *
+   * @return bool - true if server is ready, false otherwise
+   */
   bool serverReady() const override;
+  /**
+   * @brief Checks if a model/worker is ready
+   *
+   * @param model name of the model to check
+   * @return bool - true if model is ready, false otherwise
+   */
   bool modelReady(const std::string& model) const override;
+  /**
+   * @brief Returns the metadata associated with a ready model/worker
+   *
+   * @param model name of the model/worker to get metadata
+   * @return ModelMetadata
+   */
   ModelMetadata modelMetadata(const std::string& model) const override;
 
+  /**
+   * @brief Loads a model with the given name and load-time parameters. This
+   * method assumes that a directory with this model name already exists in the
+   * model repository directory for the server containing the model and its
+   * metadata in the right format.
+   *
+   * @param model name of the model to load from the model repository directory
+   * @param parameters load-time parameters for the worker supporting the model
+   */
   void modelLoad(const std::string& model,
                  RequestParameters* parameters) const override;
+  /**
+   * @brief Unloads a previously loaded model and shut it down. This is
+   * identical in functionality to workerUnload and is provided for symmetry.
+   *
+   * @param model name of the model to unload
+   */
   void modelUnload(const std::string& model) const override;
 
+  /**
+   * @brief Makes a synchronous inference request to the given model/worker. The
+   * contents of the request depends on the model/worker that the request is
+   * for.
+   *
+   * @param model name of the model/worker to request inference to
+   * @param request the request
+   * @return InferenceResponse
+   */
   InferenceResponse modelInfer(const std::string& model,
                                const InferenceRequest& request) const override;
+  /**
+   * @brief Makes an asynchronous inference request to the given model/worker.
+   * The contents of the request depends on the model/worker that the request
+   * is for. The user must save the Future object and use it to get the results
+   * of the inference later.
+   *
+   * @param model name of the model/worker to request inference to
+   * @param request the request
+   * @return InferenceResponseFuture
+   */
   InferenceResponseFuture modelInferAsync(
     const std::string& model, const InferenceRequest& request) const override;
+  /**
+   * @brief Gets a list of active models on the server, returning their names
+   *
+   * @return std::vector<std::string>
+   */
   std::vector<std::string> modelList() const override;
-  // int streamModelInferStart(const std::string& model,
-  //                           const InferenceRequest& request,
-  //                           RequestParameters& metadata) const;
-  // bool streamModelInfer(int index, InferenceResponse& response) const;
 
+  /**
+   * @brief Loads a worker with the given name and load-time parameters.
+   *
+   * @param worker name of the worker to load
+   * @param parameters load-time parameters for the worker
+   * @return std::string
+   */
   std::string workerLoad(const std::string& worker,
                          RequestParameters* parameters) const override;
+  /**
+   * @brief Unloads a previously loaded worker and shut it down. This is
+   * identical in functionality to modelUnload and is provided for symmetry.
+   *
+   * @param worker name of the worker to unload
+   */
   void workerUnload(const std::string& worker) const override;
 
+  /**
+   * @brief Checks if the server has the requested number of a specific hardware
+   * device
+   *
+   * @param name name of the hardware device to check
+   * @param num number of the device that should exist at minimum
+   * @return bool - true if server has at least the requested number of the
+   * hardware device, false otherwise
+   */
   bool hasHardware(const std::string& name, int num) const override;
 
  private:

--- a/include/amdinfer/clients/http.hpp
+++ b/include/amdinfer/clients/http.hpp
@@ -32,41 +32,157 @@
 
 namespace amdinfer {
 
+/**
+ * @brief The HttpClient class implements the Client using HTTP REST
+ *
+ * @details Usage:
+ *
+ * HttpClient client{"http://127:0.0.1:8998"};
+ * if (client.serverLive()){
+ *   ...
+ * }
+ *
+ */
 class HttpClient : public Client {
  public:
+  /**
+   * @brief Construct a new HttpClient object
+   *
+   * @param address Address of the server to connect to
+   * @param headers Key-value pairs that should be added to the HTTP headers for
+   * all requests
+   * @param parallelism Max number of requests that can be sent in parallel
+   */
   HttpClient(std::string address, const StringMap& headers = {},
              int parallelism = 32);
+  /// Copy constructor
   HttpClient(HttpClient const&);
+  /// Copy assignment constructor deleted
   HttpClient& operator=(const HttpClient&) const = delete;
+  /// Move constructor
   HttpClient(HttpClient&& other) noexcept;
+  /// Move assignment constructor deleted
   HttpClient& operator=(HttpClient&& other) const noexcept = delete;
+  /// Destructor
   ~HttpClient() override;
 
+  /**
+   * @brief Returns the server metadata as a ServerMetadata object
+   *
+   * @return ServerMetadata
+   */
   ServerMetadata serverMetadata() const override;
+  /**
+   * @brief Checks if the server is live
+   *
+   * @return bool - true if server is live, false otherwise
+   */
   bool serverLive() const override;
+  /**
+   * @brief Checks if the server is ready
+   *
+   * @return bool - true if server is ready, false otherwise
+   */
   bool serverReady() const override;
+  /**
+   * @brief Checks if a model/worker is ready
+   *
+   * @param model name of the model to check
+   * @return bool - true if model is ready, false otherwise
+   */
   bool modelReady(const std::string& model) const override;
+  /**
+   * @brief Returns the metadata associated with a ready model/worker
+   *
+   * @param model name of the model/worker to get metadata
+   * @return ModelMetadata
+   */
   ModelMetadata modelMetadata(const std::string& model) const override;
 
+  /**
+   * @brief Loads a model with the given name and load-time parameters. This
+   * method assumes that a directory with this model name already exists in the
+   * model repository directory for the server containing the model and its
+   * metadata in the right format.
+   *
+   * @param model name of the model to load from the model repository directory
+   * @param parameters load-time parameters for the worker supporting the model
+   */
   void modelLoad(const std::string& model,
                  RequestParameters* parameters) const override;
+  /**
+   * @brief Unloads a previously loaded model and shut it down. This is
+   * identical in functionality to workerUnload and is provided for symmetry.
+   *
+   * @param model name of the model to unload
+   */
   void modelUnload(const std::string& model) const override;
 
+  /**
+   * @brief Makes a synchronous inference request to the given model/worker. The
+   * contents of the request depends on the model/worker that the request is
+   * for.
+   *
+   * @param model name of the model/worker to request inference to
+   * @param request the request
+   * @return InferenceResponse
+   */
   InferenceResponse modelInfer(const std::string& model,
                                const InferenceRequest& request) const override;
+  /**
+   * @brief Makes an asynchronous inference request to the given model/worker.
+   * The contents of the request depends on the model/worker that the request
+   * is for. The user must save the Future object and use it to get the results
+   * of the inference later.
+   *
+   * @param model name of the model/worker to request inference to
+   * @param request the request
+   * @return InferenceResponseFuture
+   */
   InferenceResponseFuture modelInferAsync(
     const std::string& model, const InferenceRequest& request) const override;
+  /**
+   * @brief Gets a list of active models on the server, returning their names
+   *
+   * @return std::vector<std::string>
+   */
   std::vector<std::string> modelList() const override;
 
+  /**
+   * @brief Loads a worker with the given name and load-time parameters.
+   *
+   * @param worker name of the worker to load
+   * @param parameters load-time parameters for the worker
+   * @return std::string
+   */
   std::string workerLoad(const std::string& worker,
                          RequestParameters* parameters) const override;
+  /**
+   * @brief Unloads a previously loaded worker and shut it down. This is
+   * identical in functionality to modelUnload and is provided for symmetry.
+   *
+   * @param worker name of the worker to unload
+   */
   void workerUnload(const std::string& worker) const override;
 
+  /**
+   * @brief Checks if the server has the requested number of a specific hardware
+   * device
+   *
+   * @param name name of the hardware device to check
+   * @param num number of the device that should exist at minimum
+   * @return bool - true if server has at least the requested number of the
+   * hardware device, false otherwise
+   */
   bool hasHardware(const std::string& name, int num) const override;
 
+  /// Returns the HTTP address
   const std::string& getAddress() const&;
+  /// Returns the HTTP address
   std::string getAddress() const&&;
+  /// Returns the HTTP headers
   const StringMap& getHeaders() const&;
+  /// Returns the HTTP headers
   StringMap getHeaders() const&&;
 
  private:

--- a/include/amdinfer/clients/native.hpp
+++ b/include/amdinfer/clients/native.hpp
@@ -33,56 +33,130 @@
 
 namespace amdinfer {
 
+/**
+ * @brief The NativeClient class implements the Client using the native C++ API.
+ * This client can be used if the client and backend are in the same C++
+ * executable.
+ *
+ * @details Usage:
+ *
+ * NativeClient client;
+ * if (client.serverLive()){
+ *   ...
+ * }
+ *
+ */
 class NativeClient : public Client {
  public:
+  /**
+   * @brief Returns the server metadata as a ServerMetadata object
+   *
+   * @return ServerMetadata
+   */
   ServerMetadata serverMetadata() const override;
+  /**
+   * @brief Checks if the server is live
+   *
+   * @return bool - true if server is live, false otherwise
+   */
   bool serverLive() const override;
+  /**
+   * @brief Checks if the server is ready
+   *
+   * @return bool - true if server is ready, false otherwise
+   */
   bool serverReady() const override;
 
   /**
-   * @brief Check if a worker is ready
+   * @brief Checks if a model/worker is ready
    *
-   * @param worker name of the worker to check if ready
+   * @param model name of the model to check
+   * @return bool - true if model is ready, false otherwise
    */
   bool modelReady(const std::string& model) const override;
-
+  /**
+   * @brief Returns the metadata associated with a ready model/worker
+   *
+   * @param model name of the model/worker to get metadata
+   * @return ModelMetadata
+   */
   ModelMetadata modelMetadata(const std::string& model) const override;
 
   /**
-   * @brief Load a worker
+   * @brief Loads a model with the given name and load-time parameters. This
+   * method assumes that a directory with this model name already exists in the
+   * model repository directory for the server containing the model and its
+   * metadata in the right format.
    *
-   * @param model name of the worker to load
-   * @param parameters any load-time parameters to pass to the worker
-   * @return std::string the qualified name of the worker to make inference
-   * requests
+   * @param model name of the model to load from the model repository directory
+   * @param parameters load-time parameters for the worker supporting the model
    */
   void modelLoad(const std::string& model,
                  RequestParameters* parameters) const override;
   /**
-   * @brief Unload a worker
+   * @brief Unloads a previously loaded model and shut it down. This is
+   * identical in functionality to workerUnload and is provided for symmetry.
    *
-   * @param worker name of the worker to unload
+   * @param model name of the model to unload
    */
   void modelUnload(const std::string& model) const override;
 
+  /**
+   * @brief Makes a synchronous inference request to the given model/worker. The
+   * contents of the request depends on the model/worker that the request is
+   * for.
+   *
+   * @param model name of the model/worker to request inference to
+   * @param request the request
+   * @return InferenceResponse
+   */
   InferenceResponse modelInfer(const std::string& model,
                                const InferenceRequest& request) const override;
   /**
-   * @brief Enqueue an inference request
+   * @brief Makes an asynchronous inference request to the given model/worker.
+   * The contents of the request depends on the model/worker that the request
+   * is for. The user must save the Future object and use it to get the results
+   * of the inference later.
    *
-   * @param workerName name of the worker to make the request to
-   * @param request the request to make
-   * @return InferenceResponseFuture a future to get the results of the request
+   * @param model name of the model/worker to request inference to
+   * @param request the request
+   * @return InferenceResponseFuture
    */
   InferenceResponseFuture modelInferAsync(
-    const std::string& workerName,
-    const InferenceRequest& request) const override;
+    const std::string& model, const InferenceRequest& request) const override;
+  /**
+   * @brief Gets a list of active models on the server, returning their names
+   *
+   * @return std::vector<std::string>
+   */
   std::vector<std::string> modelList() const override;
 
+  /**
+   * @brief Loads a worker with the given name and load-time parameters.
+   *
+   * @param worker name of the worker to load
+   * @param parameters load-time parameters for the worker
+   * @return std::string
+   */
   std::string workerLoad(const std::string& worker,
                          RequestParameters* parameters) const override;
+  /**
+   * @brief Unloads a previously loaded worker and shut it down. This is
+   * identical in functionality to modelUnload and is provided for symmetry.
+   *
+   * @param worker name of the worker to unload
+   */
   void workerUnload(const std::string& worker) const override;
 
+  /**
+   * @brief Checks if the server has the requested number of a specific hardware
+   * device
+   *
+   * @param name name of the hardware device to check
+   * @param num number of the device that should exist at minimum
+   * @return bool - true if server has at least the requested number of the
+   * hardware device, false otherwise
+   */
   bool hasHardware(const std::string& name, int num) const override;
 };
 

--- a/include/amdinfer/clients/websocket.hpp
+++ b/include/amdinfer/clients/websocket.hpp
@@ -30,38 +30,168 @@
 
 namespace amdinfer {
 
+/**
+ * @brief The WebSocketClient class implements the Client using websocket. It
+ * reuses the HttpClient for most transactions with the exception of some
+ * operations that actually use websocket.
+ *
+ * @details Usage:
+ *
+ * WebSocketClient client{"ws://127.0.0.1:8998", "http://127.0.0.1:8998"};
+ * if (client.serverLive()){
+ *   ...
+ * }
+ *
+ */
 class WebSocketClient : public Client {
  public:
-  WebSocketClient() = delete;
+  /**
+   * @brief Constructs a new WebSocketClient object
+   *
+   * @param ws_address address of the websocket server to connect to
+   * @param http_address address of the HTTP server to connect to
+   */
   WebSocketClient(const std::string& ws_address,
                   const std::string& http_address);
-  ~WebSocketClient();
+  /// Destructor
+  ~WebSocketClient() override;
 
+  /**
+   * @brief Returns the server metadata as a ServerMetadata object
+   *
+   * @return ServerMetadata
+   */
   ServerMetadata serverMetadata() const override;
+  /**
+   * @brief Checks if the server is live
+   *
+   * @return bool - true if server is live, false otherwise
+   */
   bool serverLive() const override;
+  /**
+   * @brief Checks if the server is ready
+   *
+   * @return bool - true if server is ready, false otherwise
+   */
   bool serverReady() const override;
+  /**
+   * @brief Checks if a model/worker is ready
+   *
+   * @param model name of the model to check
+   * @return bool - true if model is ready, false otherwise
+   */
   bool modelReady(const std::string& model) const override;
+  /**
+   * @brief Returns the metadata associated with a ready model/worker
+   *
+   * @param model name of the model/worker to get metadata
+   * @return ModelMetadata
+   */
   ModelMetadata modelMetadata(const std::string& model) const override;
 
+  /**
+   * @brief Loads a model with the given name and load-time parameters. This
+   * method assumes that a directory with this model name already exists in the
+   * model repository directory for the server containing the model and its
+   * metadata in the right format.
+   *
+   * @param model name of the model to load from the model repository directory
+   * @param parameters load-time parameters for the worker supporting the model
+   */
   void modelLoad(const std::string& model,
                  RequestParameters* parameters) const override;
+  /**
+   * @brief Unloads a previously loaded model and shut it down. This is
+   * identical in functionality to workerUnload and is provided for symmetry.
+   *
+   * @param model name of the model to unload
+   */
   void modelUnload(const std::string& model) const override;
+
+  /**
+   * @brief Makes a synchronous inference request to the given model/worker. The
+   * contents of the request depends on the model/worker that the request is
+   * for.
+   *
+   * @param model name of the model/worker to request inference to
+   * @param request the request
+   * @return InferenceResponse
+   */
   InferenceResponse modelInfer(const std::string& model,
                                const InferenceRequest& request) const override;
+  /**
+   * @brief Makes an asynchronous inference request to the given model/worker.
+   * The contents of the request depends on the model/worker that the request
+   * is for. The user must save the Future object and use it to get the results
+   * of the inference later.
+   *
+   * @param model name of the model/worker to request inference to
+   * @param request the request
+   * @return InferenceResponseFuture
+   */
   InferenceResponseFuture modelInferAsync(
     const std::string& model, const InferenceRequest& request) const override;
+  /**
+   * @brief Gets a list of active models on the server, returning their names
+   *
+   * @return std::vector<std::string>
+   */
   std::vector<std::string> modelList() const override;
 
+  /**
+   * @brief Loads a worker with the given name and load-time parameters.
+   *
+   * @param worker name of the worker to load
+   * @param parameters load-time parameters for the worker
+   * @return std::string
+   */
   std::string workerLoad(const std::string& worker,
                          RequestParameters* parameters) const override;
+  /**
+   * @brief Unloads a previously loaded worker and shut it down. This is
+   * identical in functionality to modelUnload and is provided for symmetry.
+   *
+   * @param worker name of the worker to unload
+   */
   void workerUnload(const std::string& worker) const override;
 
+  /**
+   * @brief Checks if the server has the requested number of a specific hardware
+   * device
+   *
+   * @param name name of the hardware device to check
+   * @param num number of the device that should exist at minimum
+   * @return bool - true if server has at least the requested number of the
+   * hardware device, false otherwise
+   */
   bool hasHardware(const std::string& name, int num) const override;
 
+  /**
+   * @brief Makes a websocket inference request to the given model/worker. The
+   * contents of the request depends on the model/worker that the request is
+   * for. This method differs from the standard inference in that it submits an
+   * actual Websocket message. The user should use modelRecv to get results and
+   * must disambiguate different responses on the client-side using the IDs of
+   * the responses.
+   *
+   * @param model
+   * @param request
+   */
   void modelInferWs(const std::string& model,
                     const InferenceRequest& request) const;
-  // TODO(varunsh) const: change to InferenceReponse
+  // TODO(varunsh) const: change to InferenceResponse
+  /**
+   * @brief Gets one message from the websocket server sent in response to a
+   * modelInferWs request. The user should know beforehand how many messages are
+   * expected and should call this method the same number of times.
+   *
+   * @return std::string a JSON object encoded as a string
+   */
   std::string modelRecv() const;
+  /**
+   * @brief Closes the websocket connection
+   *
+   */
   void close() const;
 
  private:

--- a/include/amdinfer/core/data_types.hpp
+++ b/include/amdinfer/core/data_types.hpp
@@ -74,12 +74,31 @@ class DataType {
     UNKNOWN
   };
 
+  /// Constructs a new DataType object
   constexpr DataType() : value_(Value::UNKNOWN) {}
+  /**
+   * @brief Constructs a new DataType object
+   *
+   * @param value string to identify the initial value of the new datatype
+   */
   constexpr DataType(const char* value) : value_(mapStrToType(value)) {}
+  /**
+   * @brief Constructs a new DataType object
+   *
+   * @param value datatype to identify the initial value of the new datatype
+   */
   constexpr DataType(DataType::Value value) : value_(value) {}
 
+  /// Implicit conversion between the Datatype class and its internal value
   constexpr operator Value() const { return value_; }
 
+  /**
+   * @brief Print support for the DataType class
+   *
+   * @param os stream to print to
+   * @param value Datatype instance to print
+   * @return std::ostream&
+   */
   friend std::ostream& operator<<(std::ostream& os, const DataType& value);
 
   /**
@@ -197,6 +216,17 @@ class DataType {
   Value value_;
 };
 
+/**
+ * @brief Runs a callable templated function based on the type passed as an
+ * argument
+ *
+ * @tparam F a callable templated function type
+ * @tparam Args the types of arguments to the function F
+ * @param f a callable templated function to evaluate for all datatypes
+ * @param type the datatype to choose which templated function f to run
+ * @param args arguments to the function F
+ * @return auto - return value from the function f
+ */
 template <typename F, typename... Args>
 auto switchOverTypes(F f, DataType type, [[maybe_unused]] const Args&... args) {
   switch (type) {

--- a/include/amdinfer/core/exceptions.hpp
+++ b/include/amdinfer/core/exceptions.hpp
@@ -26,34 +26,71 @@
 
 namespace amdinfer {
 
+/**
+ * @brief The base class for all exceptions thrown by the inference server
+ *
+ */
 class runtime_error : public std::runtime_error {
   using std::runtime_error::runtime_error;
 };
 
+/**
+ * @brief This exception gets thrown by the clients if a method fails or the
+ * server raises an error.
+ *
+ */
 class bad_status : public runtime_error {
   using runtime_error::runtime_error;
 };
 
+/**
+ * @brief This exception gets thrown by the clients if the connection to the
+ * server fails.
+ *
+ */
 class connection_error : public bad_status {
   using bad_status::bad_status;
 };
 
+/**
+ * @brief This exception gets thrown if a requested file cannot be found
+ *
+ */
 class file_not_found_error : public runtime_error {
   using runtime_error::runtime_error;
 };
 
+/**
+ * @brief This exception gets thrown if a requested file cannot be read
+ *
+ */
 class file_read_error : public runtime_error {
   using runtime_error::runtime_error;
 };
 
+/**
+ * @brief This exception gets thrown if a third-party library raises an
+ * exception
+ *
+ */
 class external_error : public runtime_error {
   using runtime_error::runtime_error;
 };
 
+/**
+ * @brief This exception gets thrown if an invalid argument is passed to a
+ * function
+ *
+ */
 class invalid_argument : public runtime_error {
   using runtime_error::runtime_error;
 };
 
+/**
+ * @brief This exception gets thrown if an expected environment variable is not
+ * set
+ *
+ */
 class environment_not_set_error : public runtime_error {
   using runtime_error::runtime_error;
 };

--- a/include/amdinfer/core/mixins.hpp
+++ b/include/amdinfer/core/mixins.hpp
@@ -5,12 +5,33 @@
 
 namespace amdinfer {
 
+/**
+ * @brief This class can be inherited from to implement serialization and
+ * deserialization in a class.
+ */
 class Serializable {
  public:
   virtual ~Serializable() = default;
 
+  /**
+   * @brief Returns the size of the serialized data
+   *
+   * @return size_t
+   */
   virtual size_t serializeSize() const = 0;
+  /**
+   * @brief Serializes the object to the provided memory address. There should
+   * be sufficient space to store the serialized object.
+   *
+   * @param data_out
+   */
   virtual void serialize(std::byte* data_out) const = 0;
+  /**
+   * @brief Deserializes the data at the provided memory address to initialize
+   * this object. If the memory cannot be deserialized, an exception is thrown.
+   *
+   * @param data_in a pointer to the serialized data for this object type
+   */
   virtual void deserialize(const std::byte* data_in) = 0;
 };
 

--- a/include/amdinfer/core/predict_api.hpp
+++ b/include/amdinfer/core/predict_api.hpp
@@ -54,35 +54,35 @@ using Parameter = std::variant<bool, int32_t, double, std::string>;
 class RequestParameters : public Serializable {
  public:
   /**
-   * @brief Put in a key-value pair
+   * @brief Puts in a key-value pair
    *
    * @param key key used to store and retrieve the value
    * @param value value to store
    */
   void put(const std::string &key, bool value);
   /**
-   * @brief Put in a key-value pair
+   * @brief Puts in a key-value pair
    *
    * @param key key used to store and retrieve the value
    * @param value value to store
    */
   void put(const std::string &key, double value);
   /**
-   * @brief Put in a key-value pair
+   * @brief Puts in a key-value pair
    *
    * @param key key used to store and retrieve the value
    * @param value value to store
    */
   void put(const std::string &key, int32_t value);
   /**
-   * @brief Put in a key-value pair
+   * @brief Puts in a key-value pair
    *
    * @param key key used to store and retrieve the value
    * @param value value to store
    */
   void put(const std::string &key, const std::string &value);
   /**
-   * @brief Put in a key-value pair
+   * @brief Puts in a key-value pair
    *
    * @param key key used to store and retrieve the value
    * @param value value to store
@@ -90,7 +90,7 @@ class RequestParameters : public Serializable {
   void put(const std::string &key, const char *value);
 
   /**
-   * @brief Get a pointer to the named parameter. Returns nullptr if not found
+   * @brief Gets a pointer to the named parameter. Returns nullptr if not found
    * or if a bad type is used.
    *
    * @tparam T type of parameter. Must be (bool|double|int32_t|std::string)
@@ -104,36 +104,57 @@ class RequestParameters : public Serializable {
   }
 
   /**
-   * @brief Check if a particular parameter exists
+   * @brief Checks if a particular parameter exists
    *
    * @param key name of the parameter to check
    * @return bool
    */
   bool has(const std::string &key);
   /**
-   * @brief Remove a parameter
+   * @brief Removes a parameter
    *
    * @param key name of the parameter to remove
    */
   void erase(const std::string &key);
-  /// Get the number of parameters
+  /// Gets the number of parameters
   [[nodiscard]] size_t size() const;
-  /// Check if the parameters are empty
+  /// Checks if the parameters are empty
   [[nodiscard]] bool empty() const;
-  /// Get the underlying data structure holding the parameters
+  /// Gets the underlying data structure holding the parameters
   [[nodiscard]] std::map<std::string, Parameter> data() const;
 
+  /// Returns a read/write iterator to the first parameter in the object
   auto begin() { return parameters_.begin(); }
+  /// Returns a read iterator to the first parameter in the object
   auto cbegin() const { return parameters_.cbegin(); }
 
+  /// Returns a read/write iterator to one past the last parameter in the object
   auto end() { return parameters_.end(); }
+  /// Returns a read iterator to one past the last parameter in the object
   auto cend() const { return parameters_.cend(); }
 
+  /**
+   * @brief Returns the size of the serialized data
+   *
+   * @return size_t
+   */
   size_t serializeSize() const override;
+  /**
+   * @brief Serializes the object to the provided memory address. There should
+   * be sufficient space to store the serialized object.
+   *
+   * @param data_out
+   */
   void serialize(std::byte *data_out) const override;
+  /**
+   * @brief Deserializes the data at the provided memory address to initialize
+   * this object. If the memory cannot be deserialized, an exception is thrown.
+   *
+   * @param data_in a pointer to the serialized data for this object type
+   */
   void deserialize(const std::byte *data_in) override;
 
-  /// Provide an implementation to print the class with std::cout to an ostream
+  /// Provides an implementation to print the class with std::cout to an ostream
   friend std::ostream &operator<<(std::ostream &os,
                                   RequestParameters const &self) {
     std::stringstream ss;
@@ -156,8 +177,15 @@ class RequestParameters : public Serializable {
 using RequestParametersPtr = std::shared_ptr<RequestParameters>;
 
 struct ServerMetadata {
+  /// Name of the server
   std::string name;
+  /// Version of the server
   std::string version;
+  /**
+   * @brief The extensions supported by the server. The KServe specification
+   * allows servers to support custom extensions and return them with a
+   * metadata request.
+   */
   std::unordered_set<std::string> extensions;
 };
 
@@ -166,7 +194,7 @@ struct ServerMetadata {
  */
 class InferenceRequestInput : public Serializable {
  public:
-  /// Construct a new InferenceRequestInput object
+  /// Constructs a new InferenceRequestInput object
   InferenceRequestInput();
 
   /**
@@ -180,28 +208,28 @@ class InferenceRequestInput : public Serializable {
   InferenceRequestInput(void *data, std::vector<uint64_t> shape,
                         DataType dataType, std::string name = "");
 
-  /// Set the request's data
+  /// Sets the request's data
   void setData(void *buffer);
-  /// Set the request's shared data
+  /// Sets the request's shared data
   void setData(std::vector<std::byte> &&buffer);
-  /// check if the stored data is shared
+  /// Checks if the stored data is shared
   bool sharedData() const;
 
-  /// Get a pointer to the request's data
+  /// Gets a pointer to the request's data
   [[nodiscard]] void *getData() const;
 
-  /// Get the input tensor's name
+  /// Gets the input tensor's name
   const std::string &getName() const { return this->name_; }
-  /// Set the input tensor's name
+  /// Sets the input tensor's name
   void setName(std::string name);
 
-  /// Get the input tensor's shape
+  /// Gets the input tensor's shape
   const std::vector<uint64_t> &getShape() const { return this->shape_; }
-  /// Set the tensor's shape
+  /// Sets the tensor's shape
   void setShape(std::initializer_list<uint64_t> shape) { this->shape_ = shape; }
-  /// Set the tensor's shape
+  /// Sets the tensor's shape
   void setShape(const std::vector<uint64_t> &shape) { this->shape_ = shape; }
-  /// Set the tensor's shape
+  /// Sets the tensor's shape
   void setShape(const std::vector<int32_t> &shape) {
     this->shape_.reserve(shape.size());
     for (const auto &index : shape) {
@@ -209,13 +237,18 @@ class InferenceRequestInput : public Serializable {
     }
   }
 
-  /// Get the input tensor's datatype
+  /// Gets the input tensor's datatype
   DataType getDatatype() const { return this->dataType_; }
   /// Set the tensor's data type
   void setDatatype(DataType type);
 
-  /// Get the input tensor's parameters
+  /// Gets the input tensor's parameters
   RequestParameters *getParameters() const { return this->parameters_.get(); }
+  /**
+   * @brief Sets the input tensor's parameters
+   *
+   * @param parameters pointer to parameters to assign
+   */
   void setParameters(RequestParametersPtr parameters) {
     parameters_ = parameters;
   }
@@ -223,11 +256,28 @@ class InferenceRequestInput : public Serializable {
   /// Get the tensor's size (number of elements)
   size_t getSize() const;
 
+  /**
+   * @brief Returns the size of the serialized data
+   *
+   * @return size_t
+   */
   size_t serializeSize() const override;
+  /**
+   * @brief Serializes the object to the provided memory address. There should
+   * be sufficient space to store the serialized object.
+   *
+   * @param data_out
+   */
   void serialize(std::byte *data_out) const override;
+  /**
+   * @brief Deserializes the data at the provided memory address to initialize
+   * this object. If the memory cannot be deserialized, an exception is thrown.
+   *
+   * @param data_in a pointer to the serialized data for this object type
+   */
   void deserialize(const std::byte *data_in) override;
 
-  /// Provide an implementation to print the class with std::cout to an ostream
+  /// Provides an implementation to print the class with std::cout to an ostream
   friend std::ostream &operator<<(std::ostream &os,
                                   InferenceRequestInput const &my_class) {
     os << "InferenceRequestInput:\n";
@@ -264,22 +314,29 @@ class InferenceRequestInput : public Serializable {
  */
 class InferenceRequestOutput {
  public:
-  /// Construct a new Request Output object
+  /// Constructs a new Request Output object
   InferenceRequestOutput();
 
-  /// Set the request's data
+  /// Sets the request's data
   void setData(void *buffer) { this->data_ = buffer; }
 
-  /// Take the request's data
+  /// Takes the request's data
   void *getData() { return this->data_; }
 
-  /// Get the output tensor's name
+  /// Gets the output tensor's name
   std::string getName() { return this->name_; }
+  /// Set the output tensor's name
   void setName(const std::string &name);
 
+  /**
+   * @brief Sets the output tensor's parameters
+   *
+   * @param parameters pointer to parameters to assign
+   */
   void setParameters(RequestParametersPtr parameters) {
     parameters_ = parameters;
   }
+  /// @brief Gets the output tensor's parameters
   RequestParameters *getParameters() { return parameters_.get(); }
 
  private:
@@ -297,50 +354,50 @@ class InferenceRequestOutput {
  */
 class InferenceResponse {
  public:
-  /// Construct a new InferenceResponse object
+  /// Constructs a new InferenceResponse object
   InferenceResponse();
 
-  /// Construct a new InferenceResponse error object
+  /// Constructs a new InferenceResponse error object
   explicit InferenceResponse(const std::string &error);
 
-  /// Get a vector of the requested output information
+  /// Gets a vector of the requested output information
   [[nodiscard]] std::vector<InferenceResponseOutput> getOutputs() const;
   /**
-   * @brief Add an output tensor to the response
+   * @brief Adds an output tensor to the response
    *
    * @param output an output tensor
    */
   void addOutput(const InferenceResponseOutput &output);
 
-  /// Get the ID of the response
+  /// Gets the ID of the response
   std::string getID() { return id_; }
-  /// Set the ID of the response
+  /// Sets the ID of the response
   void setID(const std::string &id);
-  /// set the model name of the response
+  /// sets the model name of the response
   void setModel(const std::string &model);
-  /// get the model name of the response
+  /// gets the model name of the response
   std::string getModel();
 
-  /// Check if this is an error response
+  /// Checks if this is an error response
   bool isError() const;
-  /// Get the error message if it exists. Defaults to an empty string
+  /// Gets the error message if it exists. Defaults to an empty string
   std::string getError() const;
 
 #ifdef AMDINFER_ENABLE_TRACING
   /**
-   * @brief Set the Context object to propagate tracing data on
+   * @brief Sets the Context object to propagate tracing data on
    *
    * @param context
    */
   void setContext(StringMap &&context);
-  /// Get the response's context to use to initialize a new span
+  /// Gets the response's context to use to initialize a new span
   const StringMap &getContext() const;
 #endif
 
-  /// Get a pointer to the parameters associated with this response
+  /// Gets a pointer to the parameters associated with this response
   RequestParameters *getParameters() { return this->parameters_.get(); }
 
-  /// Provide an implementation to print the class with std::cout to an ostream
+  /// Provides an implementation to print the class with std::cout to an ostream
   friend std::ostream &operator<<(std::ostream &os,
                                   InferenceResponse const &my_class) {
     os << "Inference Response:\n";
@@ -379,20 +436,20 @@ class InferenceRequest {
   InferenceRequest() = default;
 
   /**
-   * @brief Set the request's callback function used by the last worker to
+   * @brief Sets the request's callback function used by the last worker to
    * respond back to the client
    *
    * @param callback a function pointer that accepts a InferenceResponse object
    */
   void setCallback(Callback &&callback);
   /**
-   * @brief Run the request's callback function.
+   * @brief Runs the request's callback function.
    *
    * @param response the response data
    */
   void runCallback(const InferenceResponse &response);
   /**
-   * @brief Run the request's callback function and clear it after. This
+   * @brief Runs the request's callback function and clear it after. This
    * prevents calling the callback multiple times. If this function is called
    * again, it's a no-op.
    *
@@ -400,37 +457,65 @@ class InferenceRequest {
    */
   void runCallbackOnce(const InferenceResponse &response);
   /**
-   * @brief Run the request's callback function with an error response. The
+   * @brief Runs the request's callback function with an error response. The
    * callback function is not cleared
    *
    * @param error_msg error message to send back to the client
    */
   void runCallbackError(std::string_view error_msg);
 
+  /**
+   * @brief Constructs and adds a new input tensor to this request
+   *
+   * @param data pointer to data to add
+   * @param shape shape of the data
+   * @param dataType the datatype of the data
+   * @param name the name of the input tensor
+   */
   void addInputTensor(void *data, const std::vector<uint64_t> &shape,
                       DataType dataType, const std::string &name = "");
 
+  /**
+   * @brief Adds a new input tensor to this request
+   *
+   * @param input an existing InferenceRequestInput object
+   */
   void addInputTensor(InferenceRequestInput input);
+  /**
+   * @brief Adds a new output tensor to this request
+   *
+   * @param output an existing InferenceRequestOutput object
+   */
   void addOutputTensor(const InferenceRequestOutput &output);
 
-  /// Get a vector of all the input request objects
+  /// Gets a vector of all the input request objects
   const std::vector<InferenceRequestInput> &getInputs() const;
   /// Get the number of input request objects
   size_t getInputSize();
 
-  /// Get a vector of the requested output information
+  /// Gets a vector of the requested output information
   const std::vector<InferenceRequestOutput> &getOutputs() const;
 
   /**
-   * @brief Get the ID associated with this request
+   * @brief Gets the ID associated with this request
    *
    * @return std::string
    */
   const std::string &getID() const { return id_; }
+  /**
+   * @brief Sets the ID associated with this request
+   *
+   * @param id ID to set
+   */
   void setID(const std::string &id) { id_ = id; }
 
   /// Get a pointer to the request's parameters
   RequestParameters *getParameters() const { return this->parameters_.get(); }
+  /**
+   * @brief Sets the parameters for the request
+   *
+   * @param parameters pointer to the parameters
+   */
   void setParameters(RequestParametersPtr parameters) {
     parameters_ = parameters;
   }
@@ -466,8 +551,11 @@ class ModelMetadataTensor final {
   ModelMetadataTensor(const std::string &name, DataType datatype,
                       std::vector<uint64_t> shape);
 
+  /// @brief Gets the name of the tensor
   const std::string &getName() const;
+  /// @brief Gets the datatype that this tensor accepts
   const DataType &getDataType() const;
+  /// @brief Gets the expected shape of the data
   const std::vector<uint64_t> &getShape() const;
 
  private:
@@ -484,7 +572,7 @@ class ModelMetadataTensor final {
 class ModelMetadata final {
  public:
   /**
-   * @brief Construct a new Model Metadata object
+   * @brief Constructs a new Model Metadata object
    *
    * @param name Name of the model
    * @param platform the platform this model runs on
@@ -492,7 +580,7 @@ class ModelMetadata final {
   ModelMetadata(const std::string &name, const std::string &platform);
 
   /**
-   * @brief Add an input tensor to this model
+   * @brief Adds an input tensor to this model
    *
    * @param name name of the tensor
    * @param datatype datatype of the tensor
@@ -501,7 +589,7 @@ class ModelMetadata final {
   void addInputTensor(const std::string &name, DataType datatype,
                       std::initializer_list<uint64_t> shape);
   /**
-   * @brief Add an input tensor to this model
+   * @brief Adds an input tensor to this model
    *
    * @param name name of the tensor
    * @param datatype datatype of the tensor
@@ -510,10 +598,15 @@ class ModelMetadata final {
   void addInputTensor(const std::string &name, DataType datatype,
                       std::vector<int> shape);
 
+  /**
+   * @brief Gets the input tensor' metadata for this model
+   *
+   * @return const std::vector<ModelMetadataTensor>&
+   */
   const std::vector<ModelMetadataTensor> &getInputs() const;
 
   /**
-   * @brief Add an output tensor to this model
+   * @brief Adds an output tensor to this model
    *
    * @param name name of the tensor
    * @param datatype datatype of the tensor
@@ -522,7 +615,7 @@ class ModelMetadata final {
   void addOutputTensor(const std::string &name, DataType datatype,
                        std::initializer_list<uint64_t> shape);
   /**
-   * @brief Add an output tensor to this model
+   * @brief Adds an output tensor to this model
    *
    * @param name name of the tensor
    * @param datatype datatype of the tensor
@@ -531,18 +624,19 @@ class ModelMetadata final {
   void addOutputTensor(const std::string &name, DataType datatype,
                        std::vector<int> shape);
 
+  /// @brief Gets the output tensors' metadata for this model
   const std::vector<ModelMetadataTensor> &getOutputs() const;
 
-  /// set the model's name
+  /// Sets the model's name
   void setName(const std::string &name);
-  /// get the model's name
+  /// Gets the model's name
   const std::string &getName() const;
 
   const std::string &getPlatform() const;
 
-  /// mark this model as ready/not ready
+  /// Marks this model as ready/not ready
   void setReady(bool ready);
-  /// check if this model is ready
+  /// Checks if this model is ready
   [[nodiscard]] bool isReady() const;
 
  private:

--- a/include/amdinfer/servers/server.hpp
+++ b/include/amdinfer/servers/server.hpp
@@ -25,15 +25,42 @@ namespace amdinfer {
 
 class Server {
  public:
+  /// Constructs a new Server object
   Server();
+  /// Destructor
   ~Server();
 
+  /**
+   * @brief Start the HTTP server
+   *
+   * @param port port to use for the HTTP server
+   */
   void startHttp(uint16_t port) const;
+  /// Stop the HTTP server
   void stopHttp() const;
+  /**
+   * @brief Start the gRPC server
+   *
+   * @param port port to use for the gRPC server
+   */
   void startGrpc(uint16_t port) const;
+  /// Stop the gRPC server
   void stopGrpc() const;
 
+  /**
+   * @brief Set the path to the model repository associated with this server
+   *
+   * @param path path to the model repository
+   */
   void setModelRepository(const std::filesystem::path& path) const;
+  /**
+   * @brief Turn on active monitoring of the model repository path for new
+   * files
+   *
+   * @param use_polling set to true to use polling to check the directory for
+   * new files, false to use events. Note that events may not work well on all
+   * platforms.
+   */
   void enableRepositoryMonitoring(bool use_polling) const;
 
  private:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ build-backend = "setuptools.build_meta"
 build = ["*-manylinux_x86_64"]
 # there's some issues with Python 11 and numpy
 skip = ["pp*", "cp311-manylinux_x86_64"]
+environment = { AMDINFER_ROOT= "/project" }
 
 [tool.cibuildwheel.linux]
 repair-wheel-command = [

--- a/src/amdinfer/CMakeLists.txt
+++ b/src/amdinfer/CMakeLists.txt
@@ -190,7 +190,7 @@ if(${AMDINFER_ENABLE_VITIS})
       OUTPUT_VARIABLE PY_XIR_PATH OUTPUT_STRIP_TRAILING_WHITESPACE
                                   COMMAND_ERROR_IS_FATAL ANY
     )
-    list(APPEND deb_dependencies "libpython3.6")
+    list(APPEND deb_dependencies "libpython3")
 
     install(FILES ${PY_XIR_PATH} TYPE LIB COMPONENT amdinfer_Runtime)
   endif()

--- a/tests/workers/test_aks.py
+++ b/tests/workers/test_aks.py
@@ -33,7 +33,7 @@ class TestAks:
         for num in numbers:
             input_0 = amdinfer.InferenceRequestInput()
             input_0.name = "aks"
-            input_0.setFp32Data(np.asarray([num], np.float))
+            input_0.setFp32Data(np.asarray([num], np.float32))
             input_0.shape = [1]
             input_0.datatype = amdinfer.DataType.FP32
             request.addInputTensor(input_0)


### PR DESCRIPTION
# Summary of Changes

*  Add comments on the public headers
*  Version the links in the documentation

# Motivation

Having comments in the user-facing API makes it clearer and allows IDE tools as well as documentation to show these comments.

# Implementation

Adding comments is self-explanatory.

For versioning, I added a new role in `conf.py` to show links to the repository. These links get versioned according to the version specified in `conf.py`. So when building docs, I have a script that will change the value of this version and then the generated HTML has links that point to the versioned version of the repository. The internal documentation links are defined using `ref` so they're already versioned.