### PR TITLE
Move test config to function

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -208,8 +208,7 @@ def server(xprocess, request):
 
 @pytest.fixture(scope="class")
 def load(request, server):
-    test_model: str = request.cls.model
-    test_parameters: dict = request.cls.parameters
+    test_model, test_parameters = request.cls.get_config()
 
     assert test_model
 

--- a/tests/workers/test_aks.py
+++ b/tests/workers/test_aks.py
@@ -22,8 +22,11 @@ import amdinfer
 @pytest.mark.usefixtures("load")
 @pytest.mark.extensions(["aks", "vitis"])
 class TestAks:
-    model = "aks"
-    parameters = {"batch_size": 1}
+    @staticmethod
+    def get_config():
+        model = "aks"
+        parameters = {"batch_size": 1}
+        return (model, parameters)
 
     def test_aks_0(self):
         numbers = [3.0]

--- a/tests/workers/test_echo.py
+++ b/tests/workers/test_echo.py
@@ -27,8 +27,11 @@ class TestEcho:
     Test the Echo worker
     """
 
-    model = "echo"
-    parameters = None
+    @staticmethod
+    def get_config():
+        model = "echo"
+        parameters = None
+        return (model, parameters)
 
     inputs = [3]
     golden_outputs = [4]

--- a/tests/workers/test_echo_multi.py
+++ b/tests/workers/test_echo_multi.py
@@ -24,8 +24,11 @@ class TestEchoMulti:
     Test the EchoMulti worker
     """
 
-    model = "echoMulti"
-    parameters = {"batch_size": 2, "timeout": 1000}
+    @staticmethod
+    def get_config():
+        model = "echoMulti"
+        parameters = {"batch_size": 2, "timeout": 1000}
+        return (model, parameters)
 
     inputs = [[3], [2, 7]]
     golden_outputs = [[3], [2, 7, 3, 2], [7, 3, 2]]

--- a/tests/workers/test_facedetect.py
+++ b/tests/workers/test_facedetect.py
@@ -32,11 +32,14 @@ class TestInferImageFacedetectDPUCADF8H:
     Test the facedetect worker
     """
 
-    model = "AksDetect"
-    parameters = {
-        "aks_graph_name": "facedetect",
-        "aks_graph": "${AKS_ROOT}/graph_zoo/graph_facedetect_u200_u250_amdinfer.json",
-    }
+    @staticmethod
+    def get_config():
+        model = "AksDetect"
+        parameters = {
+            "aks_graph_name": "facedetect",
+            "aks_graph": "${AKS_ROOT}/graph_zoo/graph_facedetect_u200_u250_amdinfer.json",
+        }
+        return (model, parameters)
 
     def send_request(self, request, check_asserts=True):
         """

--- a/tests/workers/test_facedetect_stream.py
+++ b/tests/workers/test_facedetect_stream.py
@@ -29,11 +29,14 @@ class TestFacedetectStream:
     Test the streaming version of facedetect
     """
 
-    model = "AksDetectStream"
-    parameters = {
-        "aks_graph_name": "facedetect",
-        "aks_graph": "${AKS_ROOT}/graph_zoo/graph_facedetect_u200_u250_amdinfer.json",
-    }
+    @staticmethod
+    def get_config():
+        model = "AksDetectStream"
+        parameters = {
+            "aks_graph_name": "facedetect",
+            "aks_graph": "${AKS_ROOT}/graph_zoo/graph_facedetect_u200_u250_amdinfer.json",
+        }
+        return (model, parameters)
 
     def construct_request(self, requested_frames_count):
         asset_key = "asset_Physicsworks.ogv"

--- a/tests/workers/test_invert_image.py
+++ b/tests/workers/test_invert_image.py
@@ -56,8 +56,11 @@ class TestInvertImage:
     Test the InvertImage worker
     """
 
-    model = "InvertImage"
-    parameters = None
+    @staticmethod
+    def get_config():
+        model = "InvertImage"
+        parameters = None
+        return (model, parameters)
 
     def send_request(self, request, image):
         """

--- a/tests/workers/test_invert_video.py
+++ b/tests/workers/test_invert_video.py
@@ -31,8 +31,11 @@ class TestInvertVideo:
     Test the InvertVideo
     """
 
-    model = "InvertVideo"
-    parameters = None
+    @staticmethod
+    def get_config():
+        model = "InvertVideo"
+        parameters = None
+        return (model, parameters)
 
     def construct_request(self, video_path, requested_frames_count):
         input_0 = amdinfer.InferenceRequestInput()

--- a/tests/workers/test_migraphx.py
+++ b/tests/workers/test_migraphx.py
@@ -74,8 +74,11 @@ class TestMigraphx:
     Test the Migraphx worker
     """
 
-    model = "Migraphx"
-    parameters = {"model": amdinfer.testing.getPathToAsset("onnx_resnet50")}
+    @staticmethod
+    def get_config():
+        model = "Migraphx"
+        parameters = {"model": amdinfer.testing.getPathToAsset("onnx_resnet50")}
+        return (model, parameters)
 
     def send_request(self, request, check_asserts=True):
         """

--- a/tests/workers/test_ptzendnn.py
+++ b/tests/workers/test_ptzendnn.py
@@ -71,13 +71,16 @@ class TestPtZendnn:
     Test the PtZendnn worker
     """
 
-    model = "PtZendnn"
-    parameters = {
-        "model": amdinfer.testing.getPathToAsset("pt_resnet50"),
-        "input_size": 224,
-        "output_classes": 1000,
-        "batch_size": 8,
-    }
+    @staticmethod
+    def get_config():
+        model = "PtZendnn"
+        parameters = {
+            "model": amdinfer.testing.getPathToAsset("pt_resnet50"),
+            "input_size": 224,
+            "output_classes": 1000,
+            "batch_size": 8,
+        }
+        return (model, parameters)
 
     def send_request(self, request, check_asserts=True):
         """

--- a/tests/workers/test_resnet50_dpucadf8h.py
+++ b/tests/workers/test_resnet50_dpucadf8h.py
@@ -30,11 +30,14 @@ class TestInferImageResNet50DPUCADF8H:
     Test the Resnet50 worker
     """
 
-    model = "resnet50"
-    parameters = {
-        "aks_graph_name": "resnet50",
-        "aks_graph": "${AKS_ROOT}/graph_zoo/graph_tf_resnet_v1_50_u200_u250_amdinfer.json",
-    }
+    @staticmethod
+    def get_config():
+        model = "resnet50"
+        parameters = {
+            "aks_graph_name": "resnet50",
+            "aks_graph": "${AKS_ROOT}/graph_zoo/graph_tf_resnet_v1_50_u200_u250_amdinfer.json",
+        }
+        return (model, parameters)
 
     def send_request(self, request, check_asserts=True):
         """

--- a/tests/workers/test_resnet50_stream.py
+++ b/tests/workers/test_resnet50_stream.py
@@ -31,8 +31,11 @@ class TestResnet50Stream:
     Test the Resnet50Stream
     """
 
-    model = "Resnet50Stream"
-    parameters = None
+    @staticmethod
+    def get_config():
+        model = "Resnet50Stream"
+        parameters = None
+        return (model, parameters)
 
     def construct_request(self, requested_frames_count):
         video_path = amdinfer.testing.getPathToAsset("asset_Physicsworks.ogv")

--- a/tests/workers/test_tfzendnn.py
+++ b/tests/workers/test_tfzendnn.py
@@ -65,17 +65,20 @@ class TestTfZendnn:
     Test the TfZendnn worker
     """
 
-    model = "TfZendnn"
-    parameters = {
-        "model": amdinfer.testing.getPathToAsset("tf_resnet50"),
-        "input_node": "input",
-        "output_node": "resnet_v1_50/predictions/Reshape_1",
-        "input_size": 224,
-        "output_classes": 1000,
-        "inter_op": 64,
-        "intra_op": 1,
-        "batch_size": 8,
-    }
+    @staticmethod
+    def get_config():
+        model = "TfZendnn"
+        parameters = {
+            "model": amdinfer.testing.getPathToAsset("tf_resnet50"),
+            "input_node": "input",
+            "output_node": "resnet_v1_50/predictions/Reshape_1",
+            "input_size": 224,
+            "output_classes": 1000,
+            "inter_op": 64,
+            "intra_op": 1,
+            "batch_size": 8,
+        }
+        return (model, parameters)
 
     def send_request(self, request, check_asserts=True):
         """

--- a/tests/workers/test_yolov3.py
+++ b/tests/workers/test_yolov3.py
@@ -33,11 +33,14 @@ class TestInferImageYoloV3DPUCADF8H:
     Test the yolov3 worker
     """
 
-    model = "AksDetect"
-    parameters = {
-        "aks_graph_name": "yolov3",
-        "aks_graph": "${AKS_ROOT}/graph_zoo/graph_yolov3_u200_u250_amdinfer.json",
-    }
+    @staticmethod
+    def get_config():
+        model = "AksDetect"
+        parameters = {
+            "aks_graph_name": "yolov3",
+            "aks_graph": "${AKS_ROOT}/graph_zoo/graph_yolov3_u200_u250_amdinfer.json",
+        }
+        return (model, parameters)
 
     def send_request(self, request, check_asserts=True):
         """

--- a/tests/workers/xmodel/test_resnet50.py
+++ b/tests/workers/xmodel/test_resnet50.py
@@ -60,8 +60,11 @@ class TestXmodel:
     Test the Xmodel worker
     """
 
-    model = "Xmodel"
-    parameters = {"model": amdinfer.testing.getPathToAsset("u250_resnet50")}
+    @staticmethod
+    def get_config():
+        model = "Xmodel"
+        parameters = {"model": amdinfer.testing.getPathToAsset("u250_resnet50")}
+        return (model, parameters)
 
     def test_xmodel_0(self):
         """


### PR DESCRIPTION
# Summary of Changes

*  Move the test configuration to a function rather than a class variable

Closes #103 

# Motivation

Since test classes are constructed at as `pytest` starts up, missing test assets that provided in the test configuration cause the test discovery to fail before anything happens. By moving this configuration to a function, missing test assets fails the particular test rather than the whole test.

# Implementation

The configuration (the name of the worker and its parameters to load) is moved to a static function in the class, which is invoked by the load fixture to prepare the server for each test.

# Notes

No changes to user code. Future tests should specify the test configuration as these tests do.
