### PR TITLE
Support building containers with custom backend versions

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -40,6 +40,8 @@ Added
 - Add batch size flag to examples (:pr:`94`)
 - Add Kubernetes test for KServe (:pr:`95`)
 - Use exhale to generate Python API documentation (:pr:`95`)
+- OpenAPI spec for REST protocol (:pr:`100`)
+- Use a timer for simpler time measurement (:pr:`104`)
 
 Changed
 ^^^^^^^
@@ -52,6 +54,18 @@ Changed
 - Reorganize Python library (:pr:`88`)
 - Rename 'proteus' to 'amdinfer' (:pr:`91`)
 - Use Ubuntu 20.04 by default for Docker (:pr:`97`)
+- Bump up to ROCm 5.4.1 (:pr:`99`)
+- Some function names changed for style (:pr:`102`)
+
+Deprecated
+^^^^^^^^^^
+
+- ALL_CAPS style enums for the DataType (:pr:`102`)
+
+Removed
+^^^^^^^
+
+- Mappings between XIR data types <-> inference server data types from public API (:pr:`102`)
 
 Fixed
 ^^^^^
@@ -61,6 +75,8 @@ Fixed
 - Align gRPC responses using non-gRPC-native data types with other input protocols (:pr:`81`)
 - Fix the Manager's destructor (:pr:`88`)
 - Fix using ``--no-user-config`` with ``proteus run`` (:pr:`89`)
+- Handle assigning user permissions if the host UID is same as UID in container (:pr:`101`)
+- Fix test discovery if some test assets are missing (:pr:`105`)
 
 :github:`0.2.0 <Xilinx/inference-server/releases/tag/v0.2.0>` - 2022-08-05
 --------------------------------------------------------------------------

--- a/docker/generate.py
+++ b/docker/generate.py
@@ -490,8 +490,8 @@ def build_tfzendnn():
         COPY $TFZENDNN_PATH /tmp/
 
         RUN echo "51b3b4093775ff2b67e06f18d01b41ac  $(basename $TFZENDNN_PATH)" | md5sum -c - \\
-            && unzip $(basename $TFZENDNN_PATH) \\
-            && cd $(basename ${TFZENDNN_PATH%.*}) \\
+            && unzip -q -d ./tfzendnn $(basename $TFZENDNN_PATH) \\
+            && cd ./tfzendnn/*/ \\
             # To avoid protobuf version issues, create subfolder and copy include files
             && mkdir -p ${COPY_DIR}/usr/include/tfzendnn/ \\
             && mkdir -p ${COPY_DIR}/usr/lib \\
@@ -508,8 +508,8 @@ def build_ptzendnn():
         COPY $PTZENDNN_PATH /tmp/
 
         RUN echo "a191f2305f1cae6e00c82a1071df9708  $(basename $PTZENDNN_PATH)" | md5sum -c - \\
-            && unzip $(basename $PTZENDNN_PATH) \\
-            && cd $(basename ${PTZENDNN_PATH%.*}) \\
+            && unzip -q -d ./ptzendnn $(basename $PTZENDNN_PATH) \\
+            && cd ./ptzendnn/*/ \\
             # To avoid protobuf version issues, create subfolder and copy include files
             && mkdir -p ${COPY_DIR}/usr/include/ptzendnn/ \\
             && mkdir -p ${COPY_DIR}/usr/lib \\
@@ -770,7 +770,12 @@ def generate(args: argparse.Namespace):
     else:
         dockerfile = dockerfile.replace("$[BUILD_OPTIONAL]", build_optional())
 
-    dockerfile = dockerfile.replace("$[INSTALL_XRT]", install_xrt(manager))
+    if args.nightly:
+        dockerfile = dockerfile.replace(
+            "$[INSTALL_XRT]", install_xrt(manager, nightly_lib)
+        )
+    else:
+        dockerfile = dockerfile.replace("$[INSTALL_XRT]", install_xrt(manager, None))
 
     if args.nightly:
         dockerfile = dockerfile.replace("$[BUILD_VITIS]", nightly_lib.build_vitis())

--- a/docker/generate.py
+++ b/docker/generate.py
@@ -213,7 +213,7 @@ def install_build_packages(manager):
             # used by thrift to build
             bison \\
             flex \\
-            # used by opentelemetry
+            # used by opentelemetry and XRT
             libcurl4-openssl-dev \\
             # used by Vitis AI
             libgoogle-glog-dev \\
@@ -305,21 +305,29 @@ def install_optional_build_packages(manager: PackageManager):
     return command
 
 
-def install_xrt(manager: PackageManager):
-    if manager.name == "apt":
-        packages = textwrap.dedent(
+def get_xrm_xrt_packages(package_manager):
+    if package_manager == "apt":
+        return textwrap.dedent(
             """\
             && wget --quiet -O xrt.deb https://www.xilinx.com/bin/public/openDownload?filename=xrt_202120.2.12.427_20.04-amd64-xrt.deb \\
             && wget --quiet -O xrm.deb https://www.xilinx.com/bin/public/openDownload?filename=xrm_202120.1.3.29_20.04-x86_64.deb \\"""
         )
-    elif manager.name == "yum":
-        packages = textwrap.dedent(
+    elif package_manager == "yum":
+        return textwrap.dedent(
             """\
             && wget --quiet -O xrt.rpm https://www.xilinx.com/bin/public/openDownload?filename=xrt_202120.2.12.427_7.8.2003-x86_64-xrt.rpm \\
             && wget --quiet -O xrm.rpm https://www.xilinx.com/bin/public/openDownload?filename=xrm_202120.1.3.29_7.8.2003-x86_64.rpm \\"""
         )
-    else:
-        raise ValueError(f"Unknown base image type: {manager.name}")
+    raise ValueError(f"Unknown base image type: {package_manager}")
+
+
+def install_xrt(manager: PackageManager, nightly):
+
+    packages = (
+        get_xrm_xrt_packages(manager.name)
+        if nightly is None
+        else nightly.get_xrm_xrt_packages(manager.name)
+    )
 
     return textwrap.dedent(
         f"""\
@@ -380,6 +388,60 @@ def build_optional():
             && cd /tmp \\
             && rm -fr /tmp/*
         """
+    )
+
+
+def build_vitis():
+    return textwrap.dedent(
+        """\
+        # install json-c 0.15 for Vitis AI runtime
+        RUN wget --quiet https://github.com/json-c/json-c/archive/refs/tags/json-c-0.15-20200726.tar.gz \\
+            && tar -xzf json-c-0.15-20200726.tar.gz \\
+            && cd json-c-json-c-0.15-20200726 \\
+            && mkdir build \\
+            && cd build \\
+            && cmake .. \\
+                -DBUILD_SHARED_LIBS=ON \\
+                -DBUILD_STATIC_LIBS=OFF \\
+                -DBUILD_TESTING=OFF \\
+                -DCMAKE_BUILD_TYPE=Release \\
+            && make -j$(($(nproc) - 1)) \\
+            && make install \\
+            && cat install_manifest.txt | xargs -i bash -c "if [ -f {} ]; then cp --parents -P {} ${COPY_DIR}; fi" \\
+            && cat install_manifest.txt > ${MANIFESTS_DIR}/json-c.txt
+
+        # Install Vitis AI runtime and build dependencies
+        RUN git clone --recursive --single-branch --branch v2.5 --depth 1 https://github.com/Xilinx/Vitis-AI.git \\
+            && export VITIS_ROOT=/tmp/Vitis-AI/src/Vitis-AI-Runtime/VART \\
+            && git clone --single-branch -b v2.0 --depth 1 https://github.com/Xilinx/rt-engine.git ${VITIS_ROOT}/rt-engine; \\
+            cd ${VITIS_ROOT}/unilog \\
+            && ./cmake.sh --clean --type=release --install-prefix /usr/local/ --build-dir ./build \\
+            && cd ./build && cat install_manifest.txt | xargs -i bash -c "if [ -f {} ]; then cp --parents -P {} ${COPY_DIR}; fi" \\
+            && cat install_manifest.txt > ${MANIFESTS_DIR}/unilog.txt \\
+            && cd ${VITIS_ROOT}/xir \\
+            && ./cmake.sh --clean --type=release --install-prefix /usr/local/ --build-dir ./build --build-python \\
+            && cd ./build && cat install_manifest.txt | xargs -i bash -c "if [ -f {} ]; then cp --parents -P {} ${COPY_DIR}; fi" \\
+            && cat install_manifest.txt > ${MANIFESTS_DIR}/xir.txt \\
+            && cd ${VITIS_ROOT}/target_factory \\
+            && ./cmake.sh --clean --type=release --install-prefix /usr/local/ --build-dir ./build \\
+            && cd ./build && cat install_manifest.txt | xargs -i bash -c "if [ -f {} ]; then cp --parents -P {} ${COPY_DIR}; fi" \\
+            && cat install_manifest.txt > ${MANIFESTS_DIR}/target_factory.txt \\
+            && cd ${VITIS_ROOT}/vart \\
+            && ./cmake.sh --clean --type=release --install-prefix /usr/local/ --cmake-options="-DBUILD_TEST=OFF" --build-python --build-dir ./build \\
+            && cd ./build && cat install_manifest.txt | xargs -i bash -c "if [ -f {} ]; then cp --parents -P {} ${COPY_DIR}; fi" \\
+            && cat install_manifest.txt > ${MANIFESTS_DIR}/vart.txt \\
+            && cd ${VITIS_ROOT}/rt-engine \\
+            # find the required components. Adding this was needed when using Boost from Ubuntu apt repositories
+            && sed -i '42i find_package(Boost COMPONENTS system filesystem thread serialization)' ./CMakeLists.txt \\
+            && ./cmake.sh --clean --build-dir=./build --type=release --cmake-options="-DXRM_DIR=/opt/xilinx/xrm/share/cmake" --cmake-options="-DBUILD_TESTS=OFF" --install-prefix /usr/local/ \\
+            && cd ./build && cat install_manifest.txt | xargs -i bash -c "if [ -f {} ]; then cp --parents -P {} ${COPY_DIR}; fi" \\
+            && cat install_manifest.txt > ${MANIFESTS_DIR}/rt-engine.txt \\
+            && cd /tmp/Vitis-AI/src/AKS \\
+            # fix bug in AKS
+            && sed -i '46i _global = nullptr;' ./src/AksTopContainer.cpp \\
+            && ./cmake.sh --clean --type=release --install-prefix /usr/local/ --build-dir ./build \\
+            && cd ./build && cat install_manifest.txt | xargs -i bash -c "if [ -f {} ]; then cp --parents -P {} ${COPY_DIR}; fi" \\
+            && cp install_manifest.txt ${MANIFESTS_DIR}/aks.txt"""
     )
 
 
@@ -572,15 +634,14 @@ def install_dev_packages(manager: PackageManager, core):
     )
 
 
-migraphx_apt_repo = 'echo "deb [arch=amd64 trusted=yes] http://repo.radeon.com/rocm/apt/5.4.1/ ubuntu main" > /etc/apt/sources.list.d/rocm.list'
-migraphx_yum_repo = '"[ROCm]\\nname=ROCm\\nbaseurl=https://repo.radeon.com/rocm/yum/5.4.1/\\nenabled=1\\ngpgcheck=1\\ngpgkey=https://repo.radeon.com/rocm/rocm.gpg.key" > /etc/yum.repos.d/rocm.repo'
+def install_migraphx(manager: PackageManager, nightly):
+    migraphx_apt_repo = 'echo "deb [arch=amd64 trusted=yes] http://repo.radeon.com/rocm/apt/5.4.1/ ubuntu main" > /etc/apt/sources.list.d/rocm.list'
+    migraphx_yum_repo = '"[ROCm]\\nname=ROCm\\nbaseurl=https://repo.radeon.com/rocm/yum/5.4.1/\\nenabled=1\\ngpgcheck=1\\ngpgkey=https://repo.radeon.com/rocm/rocm.gpg.key" > /etc/yum.repos.d/rocm.repo'
 
-
-def install_migraphx(manager: PackageManager):
     if manager.name == "apt":
-        add_repo = migraphx_apt_repo
+        add_repo = migraphx_apt_repo if nightly is None else nightly.migraphx_apt_repo
     elif manager.name == "yum":
-        add_repo = migraphx_yum_repo
+        add_repo = migraphx_yum_repo if nightly is None else nightly.migraphx_yum_repo
     else:
         raise ValueError(f"Unknown base image type: {manager.name}")
 
@@ -711,6 +772,11 @@ def generate(args: argparse.Namespace):
 
     dockerfile = dockerfile.replace("$[INSTALL_XRT]", install_xrt(manager))
 
+    if args.nightly:
+        dockerfile = dockerfile.replace("$[BUILD_VITIS]", nightly_lib.build_vitis())
+    else:
+        dockerfile = dockerfile.replace("$[BUILD_VITIS]", build_vitis())
+
     dockerfile = dockerfile.replace("$[INSTALL_VITIS]", install_vitis(manager))
 
     if args.nightly:
@@ -740,7 +806,14 @@ def generate(args: argparse.Namespace):
             "$[INSTALL_PYTHON_PACKAGES]", install_python_packages()
         )
 
-    dockerfile = dockerfile.replace("$[INSTALL_MIGRAPHX]", install_migraphx(manager))
+    if args.nightly:
+        dockerfile = dockerfile.replace(
+            "$[INSTALL_MIGRAPHX]", install_migraphx(manager, nightly_lib)
+        )
+    else:
+        dockerfile = dockerfile.replace(
+            "$[INSTALL_MIGRAPHX]", install_migraphx(manager, None)
+        )
 
     if args.cibuildwheel:
         entrypoint = textwrap.dedent(

--- a/src/amdinfer/core/data_types_internal.cpp
+++ b/src/amdinfer/core/data_types_internal.cpp
@@ -29,11 +29,12 @@
 #include <xir/util/data_type.hpp>  // for DataType, DataType::FLOAT, DataTyp...
 #endif
 
+#ifdef AMDINFER_ENABLE_VITIS
+
 namespace amdinfer {
 
 const auto kBitsInByte = 8;
 
-#ifdef AMDINFER_ENABLE_VITIS
 DataType mapXirToType(xir::DataType type) {
   auto data_type = type.type;
   size_t width = type.bit_width / kBitsInByte;
@@ -111,6 +112,6 @@ xir::DataType mapTypeToXir(DataType type) {
   return retval;
 }
 
-#endif
-
 }  // namespace amdinfer
+
+#endif


### PR DESCRIPTION
# Summary of Changes

* Building the backends (e.g. VAI, ZenDNN and MIGraphX) is moved into the Python script
* The Dockerfile generation script adds a hook to pass custom functions
* New `--custom-backends` flag for `docker/generate.py` to pass a path to a Python script

# Motivation

This change adds flexibility with building Docker images using different versions of the backends other than the default one that the server is using.

# Implementation

Previously, the process to build or download the backends was hardcoded into either the Dockerfile template or in the `generate.py` script. The idea here is that now it's all moved to the `generate.py` script, which has a new flag that lets you pass a path to a Python script. During the Dockerfile generation, the script will check if you passed this flag. If you didn't, it will use the default steps which are the same as before by calling a function. If you did pass a flag, it will look for the same function in the Python file you provided and use its output instead.

The needed functions and variables in your custom script aren't documented yet but you can figure it out by looking at the `generate` script and seeing what functions/variables it's using from the `custom_backends` module.

# Notes

To enable this, you need to pass `--custom_backends /path/to/file` to `docker/generate.py`. If you don't, then nothing changes and the default container is built as usual.
