### PR TITLE
Use RTLD_DEEPBIND for TF+ZenDNN

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,7 @@ endif()
 project(
   amdinfer
   VERSION ${ver_major}.${ver_minor}.${ver_patch}
-  LANGUAGES CXX
+  LANGUAGES C CXX
   DESCRIPTION "AMDinfer inference library and server"
 )
 
@@ -54,12 +54,10 @@ if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
   set(CMAKE_POSITION_INDEPENDENT_CODE ON)
   set(CMAKE_CXX_LINKER_WRAPPER_FLAG "-Wl,")
   add_link_options("LINKER:--as-needed")
-  if(NOT SKBUILD)
-    # For manylinux builds, the Python extension is intentionally not linked
-    # against Python at compile time so we need to allow undefined symbols
-    add_link_options("LINKER:--no-undefined")
-    add_link_options("LINKER:--no-allow-shlib-undefined")
-  endif()
+  # cannot use linker options like --no-undefined and --no-allow-shlib-undefined
+  # because for manylinux builds, the Python extension is intentionally not
+  # linked against Python at compile time so we need to allow undefined symbols.
+  # The workers are also not fully linked either.
   set(CMAKE_CONFIGURATION_TYPES "Debug;Release;Coverage"
       CACHE STRING "Available build-types: Debug, Release and Coverage"
   )

--- a/docker/generate.py
+++ b/docker/generate.py
@@ -496,8 +496,8 @@ def build_tfzendnn():
             && mkdir -p ${COPY_DIR}/usr/include/tfzendnn/ \\
             && mkdir -p ${COPY_DIR}/usr/lib \\
             # copy and list files that are copied
-            && cp -rv include/* ${COPY_DIR}/usr/include/tfzendnn | cut -d"'" -f 4 > ${MANIFESTS_DIR}/tfzendnn.txt \\
-            && cp -rv lib/*.so* ${COPY_DIR}/usr/lib | cut -d"'" -f 4 >> ${MANIFESTS_DIR}/tfzendnn.txt"""
+            && cp -rv include/* ${COPY_DIR}/usr/include/tfzendnn | cut -d"'" -f 2 | sed 's/include/\/usr\/include\/tfzendnn/' > ${MANIFESTS_DIR}/tfzendnn.txt \\
+            && cp -rv lib/*.so* ${COPY_DIR}/usr/lib | cut -d"'" -f 2 | sed 's/lib/\/usr\/lib/' >> ${MANIFESTS_DIR}/tfzendnn.txt"""
     )
 
 
@@ -514,8 +514,8 @@ def build_ptzendnn():
             && mkdir -p ${COPY_DIR}/usr/include/ptzendnn/ \\
             && mkdir -p ${COPY_DIR}/usr/lib \\
             # copy and list files that are copied
-            && cp -rv include/* ${COPY_DIR}/usr/include/ptzendnn | cut -d"'" -f 4 > ${MANIFESTS_DIR}/ptzendnn.txt \\
-            && cp -rv lib/*.so* ${COPY_DIR}/usr/lib | cut -d"'" -f 4 >> ${MANIFESTS_DIR}/ptzendnn.txt
+            && cp -rv include/* ${COPY_DIR}/usr/include/ptzendnn | cut -d"'" -f 2 | sed 's/include/\/usr\/include\/ptzendnn/' > ${MANIFESTS_DIR}/ptzendnn.txt \\
+            && cp -rv lib/*.so* ${COPY_DIR}/usr/lib | cut -d"'" -f 2 | sed 's/lib/\/usr\/lib/' >> ${MANIFESTS_DIR}/ptzendnn.txt
 
         # build jemalloc 5.3.0. Build uses autoconf implicitly
         RUN VERSION=5.3.0 \\

--- a/docker/get_dynamic_dependencies.sh
+++ b/docker/get_dynamic_dependencies.sh
@@ -197,6 +197,19 @@ add_migraphx_deps() {
   done
 }
 
+add_tfzendnn_deps() {
+  # these files are opened with dlopen in the tfzendnn worker and so don't show
+  # up with ldd
+  other_files=(
+    /lib/libiomp5.so
+    /lib/libtensorflow_cc.so
+  )
+
+  for file in ${other_files[@]}; do
+    get_dependencies $file
+  done
+}
+
 add_other_bins() {
   # any other binary dependencies needed
 
@@ -234,6 +247,7 @@ main() {
   COPY=""
   VITIS=""
   MIGRAPHX=""
+  TFZENDNN=""
 
   # Parse Options
   while true; do
@@ -248,6 +262,7 @@ main() {
       "-c" | "--copy" ) COPY=$2    ; shift 2 ;;
       "--vitis"       ) VITIS=$2   ; shift 2 ;;
       "--migraphx"    ) MIGRAPHX=$2; shift 2 ;;
+      "--tfzendnn"    ) TFZENDNN=$2; shift 2 ;;
       *) break;;
     esac
   done
@@ -263,6 +278,10 @@ main() {
 
   if [[ $MIGRAPHX == "yes" ]]; then
     add_migraphx_deps
+  fi
+
+  if [[ $TFZENDNN == "yes" ]]; then
+    add_tfzendnn_deps
   fi
 
   add_other_bins

--- a/docker/template.dockerfile
+++ b/docker/template.dockerfile
@@ -602,6 +602,7 @@ ARG MANIFESTS_DIR
 ARG AMDINFER_ROOT
 ARG ENABLE_VITIS
 ARG ENABLE_MIGRAPHX
+ARG ENABLE_TFZENDNN
 
 COPY . $AMDINFER_ROOT
 
@@ -615,8 +616,9 @@ RUN ldconfig \
     && ./amdinfer install --get-manifest > ${MANIFESTS_DIR}/amdinfer.txt \
     # get all the runtime shared library dependencies for the server
     && cd ${AMDINFER_ROOT} \
-    && ./docker/get_dynamic_dependencies.sh --vitis ${ENABLE_VITIS} > ${MANIFESTS_DIR}/prod.txt \
-    && ./docker/get_dynamic_dependencies.sh --copy ${COPY_DIR} --vitis ${ENABLE_VITIS}
+    # --migraphx is not passed since it's installed from debians below
+    && ./docker/get_dynamic_dependencies.sh --vitis ${ENABLE_VITIS} --tfzendnn ${ENABLE_TFZENDNN} > ${MANIFESTS_DIR}/prod.txt \
+    && ./docker/get_dynamic_dependencies.sh --copy ${COPY_DIR} --vitis ${ENABLE_VITIS} --tfzendnn ${ENABLE_TFZENDNN}
 
 FROM ${BASE_IMAGE} AS vitis_installer_prod_yes
 

--- a/examples/resnet50/CMakeLists.txt
+++ b/examples/resnet50/CMakeLists.txt
@@ -15,7 +15,9 @@
 list(APPEND examples)
 
 if(${AMDINFER_ENABLE_VITIS})
-  list(APPEND examples vitis)
+  if(${AMDINFER_ENABLE_REST})
+    list(APPEND examples vitis)
+  endif()
 endif()
 
 if(${AMDINFER_ENABLE_PTZENDNN})
@@ -23,11 +25,15 @@ if(${AMDINFER_ENABLE_PTZENDNN})
 endif()
 
 if(${AMDINFER_ENABLE_TFZENDNN})
-  list(APPEND examples tfzendnn)
+  if(${AMDINFER_ENABLE_GRPC})
+    list(APPEND examples tfzendnn)
+  endif()
 endif()
 
 if(${AMDINFER_ENABLE_MIGRAPHX})
-  list(APPEND examples migraphx)
+  if(${AMDINFER_ENABLE_REST})
+    list(APPEND examples migraphx)
+  endif()
 endif()
 
 foreach(example ${examples})
@@ -37,33 +43,3 @@ foreach(example ${examples})
     ${target} PRIVATE opencv_imgcodecs opencv_imgproc opencv_core
   )
 endforeach()
-
-# if(${AMDINFER_ENABLE_TFZENDNN})
-#   add_executable(tf_zendnn_client tf_zendnn_client.cpp)
-
-#   target_link_libraries(
-#     tf_zendnn_client PRIVATE amdinfer util opencv_imgcodecs opencv_imgproc
-#                              opencv_core
-#   )
-#   target_include_directories(tf_zendnn_client PRIVATE ${AMDINFER_INCLUDE_DIRS})
-# endif()
-
-# if(${AMDINFER_ENABLE_PTZENDNN})
-#   add_executable(pt_zendnn_client pt_zendnn_client.cpp)
-
-#   target_link_libraries(
-#     pt_zendnn_client PRIVATE amdinfer util opencv_imgcodecs opencv_imgproc
-#                              opencv_core
-#   )
-#   target_include_directories(pt_zendnn_client PRIVATE ${AMDINFER_INCLUDE_DIRS})
-# endif()
-
-# if(${AMDINFER_ENABLE_MIGRAPHX})
-#   add_executable(migraphx_client migraphx_client.cpp)
-
-#   target_link_libraries(
-#     migraphx_client PRIVATE amdinfer util opencv_imgcodecs opencv_imgproc
-#                             opencv_core migraphx::c
-#   )
-#   target_include_directories(migraphx_client PRIVATE ${AMDINFER_INCLUDE_DIRS})
-# endif()

--- a/examples/resnet50/tfzendnn.cpp
+++ b/examples/resnet50/tfzendnn.cpp
@@ -115,7 +115,7 @@ std::string load(const amdinfer::Client* client, const Args& args) {
   // a particular backend. This guard checks to make sure the server does
   // support the requested backend. If you already know it's supported, you can
   // skip this check.
-  if (!serverHasExtension(client, "ptzendnn")) {
+  if (!serverHasExtension(client, "tfzendnn")) {
     std::cerr
       << "TF+ZenDNN is not enabled. Please recompile with it enabled to "
       << "run this example\n";

--- a/src/amdinfer/CMakeLists.txt
+++ b/src/amdinfer/CMakeLists.txt
@@ -22,7 +22,7 @@ set_target_properties(
 )
 
 target_link_libraries(
-  amdinfer-server-exe PRIVATE batching clients core observation util servers
+  amdinfer-server-exe PRIVATE amdinfer Jsoncpp_lib Drogon::Drogon
 )
 
 add_subdirectory(batching)
@@ -55,23 +55,29 @@ add_library(
   ${HELPER_OBJS}
   ${OBSERVATION_OBJS}
   ${SERVER_OBJS}
+  ${UTIL_OBJS}
 )
 target_link_libraries(
-  amdinfer PRIVATE batching clients core observation util servers
+  amdinfer PRIVATE batching clients core observation servers util
 )
 
 add_library(
-  amdinfer-server ${TYPE} ${BATCHING_OBJS} ${CORE_OBJS} ${HELPER_OBJS}
-                  ${OBSERVATION_OBJS} ${SERVER_OBJS}
+  amdinfer-server
+  ${TYPE}
+  ${BATCHING_OBJS}
+  ${CORE_OBJS}
+  ${HELPER_OBJS}
+  ${OBSERVATION_OBJS}
+  ${SERVER_OBJS}
+  ${UTIL_OBJS}
 )
-target_link_libraries(
-  amdinfer-server PRIVATE batching core observation util servers
-)
+target_link_libraries(amdinfer-server PRIVATE batching core observation servers)
 
 add_library(
   amdinfer-client ${TYPE} ${CLIENT_OBJS} ${CORE_OBJS} ${OBSERVATION_OBJS}
+                  ${UTIL_OBJS}
 )
-target_link_libraries(amdinfer-client PRIVATE clients core observation util)
+target_link_libraries(amdinfer-client PRIVATE clients core observation)
 
 set(output_libraries amdinfer amdinfer-server amdinfer-client)
 foreach(lib ${output_libraries})

--- a/src/amdinfer/bindings/python/clients/CMakeLists.txt
+++ b/src/amdinfer/bindings/python/clients/CMakeLists.txt
@@ -29,10 +29,7 @@ foreach(target ${targets})
     ${target}_py PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/..
                          ${AMDINFER_INCLUDE_DIRS} ${Python_INCLUDE_DIRS}
   )
-  target_link_libraries(
-    ${target}_py PRIVATE ${Python_LIBRARIES} ${target}
-                         $<TARGET_OBJECTS:${target}>
-  )
+  target_link_libraries(${target}_py PRIVATE ${Python_LIBRARIES} amdinfer)
   add_dependencies(${target}_py pybind11Mkdoc)
 
   set(LINK_TARGETS ${LINK_TARGETS} ${target}_py)

--- a/src/amdinfer/bindings/python/core/CMakeLists.txt
+++ b/src/amdinfer/bindings/python/core/CMakeLists.txt
@@ -33,10 +33,7 @@ foreach(target ${TARGETS})
     ${target}_py PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/..
                          ${AMDINFER_INCLUDE_DIRS} ${Python_INCLUDE_DIRS}
   )
-  target_link_libraries(
-    ${target}_py PRIVATE ${Python_LIBRARIES} ${target}
-                         $<TARGET_OBJECTS:${target}>
-  )
+  target_link_libraries(${target}_py PRIVATE ${Python_LIBRARIES} amdinfer)
   add_dependencies(${target}_py pybind11Mkdoc)
 
   set(LINK_TARGETS ${LINK_TARGETS} ${target}_py)

--- a/src/amdinfer/bindings/python/servers/CMakeLists.txt
+++ b/src/amdinfer/bindings/python/servers/CMakeLists.txt
@@ -23,10 +23,7 @@ foreach(target ${TARGETS})
     ${target}_py PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/..
                          ${AMDINFER_INCLUDE_DIRS} ${Python_INCLUDE_DIRS}
   )
-  target_link_libraries(
-    ${target}_py PRIVATE ${Python_LIBRARIES} ${target}
-                         $<TARGET_OBJECTS:${target}>
-  )
+  target_link_libraries(${target}_py PRIVATE ${Python_LIBRARIES} amdinfer)
   add_dependencies(${target}_py pybind11Mkdoc)
 
   set(LINK_TARGETS ${LINK_TARGETS} ${target}_py)

--- a/src/amdinfer/bindings/python/src/amdinfer/__init__.py
+++ b/src/amdinfer/bindings/python/src/amdinfer/__init__.py
@@ -15,10 +15,22 @@
 
 import functools
 import multiprocessing as mp
+import os
 import sys
 import time
 
+# By default, Python uses only RTLD_NOW as the dlopen flag. When using
+# RTLD_DEEPBIND to open shared libraries from the inference server, specifying
+# RTLD_GLOBAL is needed for the loaded library to resolve symbols from the main
+# library. RTLD_LAZY is added to match the settings used for dlopen in C++.
+# RTLD_DEEPBIND cannot be added here. You get a segmentation fault from Pybind11
+# if you do so.
+flags = sys.getdlopenflags()
+sys.setdlopenflags(os.RTLD_GLOBAL | os.RTLD_LAZY)
+
 from ._amdinfer import *
+
+sys.setdlopenflags(flags)
 
 
 def _set_data(input_n, image):

--- a/src/amdinfer/servers/CMakeLists.txt
+++ b/src/amdinfer/servers/CMakeLists.txt
@@ -31,7 +31,7 @@ foreach(target ${targets})
   list(APPEND SERVER_OBJS $<TARGET_OBJECTS:${target}>)
 endforeach()
 
-target_link_libraries(server PRIVATE Jsoncpp_lib core)
+target_link_libraries(server PRIVATE Jsoncpp_lib core observation)
 
 if(${AMDINFER_ENABLE_AKS})
   target_link_libraries(server INTERFACE aks)

--- a/src/amdinfer/util/CMakeLists.txt
+++ b/src/amdinfer/util/CMakeLists.txt
@@ -43,3 +43,5 @@ set_target_properties(util PROPERTIES OUTPUT_NAME amdinfer-util)
 set_target_properties(
   util PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/..
 )
+
+set(UTIL_OBJS ${UTIL_OBJS} PARENT_SCOPE)

--- a/src/amdinfer/workers/CMakeLists.txt
+++ b/src/amdinfer/workers/CMakeLists.txt
@@ -88,7 +88,7 @@ if(${AMDINFER_ENABLE_TFZENDNN})
     workerTfzendnn SYSTEM BEFORE PRIVATE /usr/include/tfzendnn
   )
   target_link_libraries(
-    # not linking to tensoerflow libraries (see the tfzendnn worker)
+    # not linking to tensorflow libraries (see the tfzendnn worker)
     workerTfzendnn PRIVATE ${CMAKE_DL_LIBS}
   )
 endif()

--- a/src/amdinfer/workers/CMakeLists.txt
+++ b/src/amdinfer/workers/CMakeLists.txt
@@ -56,10 +56,7 @@ foreach(worker ${workers})
   set(worker_name worker${worker_pascal})
 
   add_library(${worker_name} SHARED ${file_name}.cpp)
-  target_link_options(${worker_name} PUBLIC "LINKER:-E")
-  target_link_libraries(
-    ${worker_name} PRIVATE batching buffers core observation timer
-  )
+  target_link_libraries(${worker_name} PRIVATE buffers)
   target_include_directories(${worker_name} PRIVATE ${AMDINFER_INCLUDE_DIRS})
   enable_ipo_on_target(${worker_name})
 
@@ -88,9 +85,12 @@ endif()
 
 if(${AMDINFER_ENABLE_TFZENDNN})
   target_include_directories(
-    workerTfzendnn SYSTEM PRIVATE /usr/include/tfzendnn
+    workerTfzendnn SYSTEM BEFORE PRIVATE /usr/include/tfzendnn
   )
-  target_link_libraries(workerTfzendnn PRIVATE tensorflow_cc)
+  target_link_libraries(
+    # not linking to tensoerflow libraries (see the tfzendnn worker)
+    workerTfzendnn PRIVATE ${CMAKE_DL_LIBS}
+  )
 endif()
 
 if(${AMDINFER_ENABLE_PTZENDNN})
@@ -123,19 +123,8 @@ if(${AMDINFER_ENABLE_AKS})
     add_library(${worker_name} SHARED ${file_name}.cpp)
     target_link_options(${worker_name} PUBLIC "LINKER:-E")
     target_link_libraries(
-      ${worker_name}
-      PRIVATE batching
-              buffers
-              core
-              base64
-              parse_env
-              timer
-              observation
-              aks
-              vart-runner
-              xir
-              opencv_core
-              opencv_imgcodecs
+      ${worker_name} PRIVATE buffers aks vart-runner xir opencv_core
+                             opencv_imgcodecs
     )
     target_include_directories(${worker_name} PRIVATE ${AMDINFER_INCLUDE_DIRS})
     add_dependencies(${worker_name} aks-kernels)
@@ -151,11 +140,7 @@ if(${AMDINFER_ENABLE_AKS})
 
   # AKS Worker
   add_library(workerAks SHARED aks.cpp)
-  target_link_options(workerAks PUBLIC "LINKER:-E")
-  target_link_libraries(
-    workerAks PRIVATE batching buffers core parse_env observation
-    PRIVATE aks vart-runner xir timer
-  )
+  target_link_libraries(workerAks PRIVATE buffers aks vart-runner xir timer)
   target_include_directories(workerAks PRIVATE ${AMDINFER_INCLUDE_DIRS})
   enable_ipo_on_target(workerAks)
   list(APPEND WORKER_TARGETS workerAks)

--- a/src/amdinfer/workers/tf_zendnn.cpp
+++ b/src/amdinfer/workers/tf_zendnn.cpp
@@ -17,7 +17,8 @@
  * @brief Implements the TfZendnn worker
  */
 
-#include <tensorflow/c/c_api.h>                         // for TF_Version
+#include <dlfcn.h>               // for dlerror, dlopen, dlsym, RTLD...
+#include <tensorflow/c/c_api.h>  // for TF_Version
 #include <tensorflow/core/framework/graph.pb.h>         // for GraphDef
 #include <tensorflow/core/framework/tensor.h>           // for Tensor
 #include <tensorflow/core/framework/tensor_shape.h>     // for TensorShape
@@ -377,12 +378,34 @@ void TfZendnn::doRelease() {
 void TfZendnn::doDeallocate() {}
 void TfZendnn::doDestroy() {}
 
+void* openLibrary(const char* library, int dlopen_flags) {
+  void* handle = dlopen(library, dlopen_flags);
+  if (handle == nullptr) {
+    const char* error_str = dlerror();
+    throw amdinfer::file_not_found_error(error_str);
+  }
+  return handle;
+}
+
 }  // namespace amdinfer::workers
 
 extern "C" {
 // using smart pointer here may cause problems inside shared object so managing
 // manually
 amdinfer::workers::Worker* getWorker() {
+  using amdinfer::workers::openLibrary;
+  // Due to the DEEPBIND change for tensorflow_cc.so below, OMP now gives a
+  // segfault unexpectedly if the server is run from Python. Preloading iomp
+  // without DEEPBIND addresses this problem.
+  openLibrary("libiomp5.so", RTLD_LOCAL | RTLD_LAZY);
+  // Upcoming changes in Tensorflow move the Protobuf symbols defined in this
+  // library to another library called tensorflow_framework.so. AT runtime,
+  // tensorflow_cc then resolves its missing protobuf symbols against the
+  // protobuf used in the inference server rather than from
+  // tensorflow_framework. Using DEEPBIND addresses this problem so the protobuf
+  // symbols get found correctly.
+  openLibrary("libtensorflow_cc.so", RTLD_LOCAL | RTLD_LAZY | RTLD_DEEPBIND);
+
   return new amdinfer::workers::TfZendnn("TfZendnn", "cpu");
 }
 }  // extern C

--- a/src/amdinfer/workers/tf_zendnn.cpp
+++ b/src/amdinfer/workers/tf_zendnn.cpp
@@ -404,7 +404,7 @@ amdinfer::workers::Worker* getWorker() {
   // protobuf used in the inference server rather than from
   // tensorflow_framework. Using DEEPBIND addresses this problem so the protobuf
   // symbols get found correctly.
-  openLibrary("libtensorflow_cc.so", RTLD_LOCAL | RTLD_LAZY | RTLD_DEEPBIND);
+  openLibrary("libtensorflow_cc.so", RTLD_GLOBAL | RTLD_LAZY | RTLD_DEEPBIND);
 
   return new amdinfer::workers::TfZendnn("TfZendnn", "cpu");
 }


### PR DESCRIPTION
# Summary of Changes

* Use `dlopen` to open Tensorflow library for TF+ZenDNN
* Remove extra linkages in libraries
* Fix shutdown race condition with gRPC

# Motivation

An upcoming change in the Tensorflow version used by `tfzednn` creates a symbol conflict between it and the inference server due to mismatching protobuf symbols. In the change, the correct protobuf symbols are located in another TF library but these symbols aren't found because the server is already linking protobuf.

# Implementation

I and @amuralee-amd explored many options to find a workable solution to resolve the symbol conflict. For future reference, here's what I tried:

1. Using `RTLD_DEEPBIND` for all workers. This is a good idea in theory because this library version mismatch occurred now with tfzendnn but it can happen again with other workers. Using this option for loading all workers should isolate them. Unfortunately, this creates a number of problems. `std::cout` stops working in the loaded shared library and certain functions in `libstdc++` raise `bad_cast` exceptions.
2. Not linking the workers to `libamdinfer.so` was done in part to address another issue with using `RTLD_DEEPBIND` which resulted in some global symbols like the logger not being correctly initialized in the loaded library. By not linking it, the worker would refer back to the version in the global scope instead.
3. Using `dlmopen` instead of `dlopen` to load the library in a different namespace creates different problems. For example, `gdb` can't easily peer into the loaded library. There are also other posts online discussing the various issues around using `dlmopen`
4. Certain fixes I tried worked in some cases but not others. Currently, there are the Python examples (which may or may not start the server from Python), the C++ examples, and the tests. I don't know enough about how the load-time process works in C++ to begin to compare it to how Python is doing it to wrapped library made with Pybind11.
5. Building the workers with `-nodefaultlibs` and similar flags to avoid linking the standard library (and hopefully let it resolve from the main scope) also didn't work at compile time. Manually editing the `.dynamic` section to remove libraries with [patchelf](https://github.com/NixOS/patchelf) also didn't work (though removing `libc` did have an effect in that `free()` stopped working).
6. Using a trampoline utility like [Implib.so](https://github.com/yugr/Implib.so) didn't work either. You get missing symbols possibly related to the vtables but adding the vtables for `libtensorflow_cc.so` took too long to generate.
7. I found a Python command `os.setdlopenflags()` that I needed to use to change the flags used by Python to work with libraries that have been opened with `RTLD_DEEPBIND`.
8. Having TF produce a single library instead of two would require a lot of changes to the TF build system and issues with the legal scan - @amuralee-amd