### PR TITLE
Support using custom classes for memory in the pool

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,7 +101,7 @@ if(NOT HALF_INCLUDE)
 endif()
 
 find_package(xir QUIET)
-find_package(vart CONFIG COMPONENTS runner util QUIET)
+find_package(vart CONFIG COMPONENTS runner util buffer-object QUIET)
 find_package(rt-engine QUIET)
 find_package(unilog QUIET)
 find_package(target-factory QUIET)

--- a/docs/assets/buffer_lifecycle.png
+++ b/docs/assets/buffer_lifecycle.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:aba28f0b81199a13e3bbe68b8720beebdde4dad7f704479ed108420eeb1a3095
-size 36245

--- a/src/amdinfer/batching/hard.cpp
+++ b/src/amdinfer/batching/hard.cpp
@@ -95,9 +95,7 @@ void HardBatcher::doRun(const std::vector<MemoryAllocators>& allocators) {
         // output_buffers.reserve(output_sizes.size());
         // std::vector<size_t> output_offset(output_buffers.size(), 0);
         for (const auto& input : inputs) {
-          input_buffers.push_back(pool_->get(
-            allocators,
-            input.getSize() * input.getDatatype().size() * batch_size_));
+          input_buffers.push_back(pool_->get(allocators, input, batch_size_));
         }
         // for(const auto& tensor_size : output_sizes) {
         //   output_buffers.push_back(pool_->get(allocators, tensor_size));

--- a/src/amdinfer/batching/soft.cpp
+++ b/src/amdinfer/batching/soft.cpp
@@ -127,9 +127,7 @@ void SoftBatcher::doRun(const std::vector<MemoryAllocators>& allocators) {
         // output_buffers.reserve(output_sizes.size());
         // std::vector<size_t> output_offset(output_buffers.size(), 0);
         for (const auto& input : inputs) {
-          input_buffers.push_back(pool_->get(
-            allocators,
-            input.getSize() * input.getDatatype().size() * batch_size_));
+          input_buffers.push_back(pool_->get(allocators, input, batch_size_));
         }
         // for(const auto& tensor_size : output_sizes) {
         //   output_buffers.push_back(pool_->get(allocators, tensor_size));

--- a/src/amdinfer/buffers/CMakeLists.txt
+++ b/src/amdinfer/buffers/CMakeLists.txt
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-list(APPEND targets cpu)
+list(APPEND targets cpu vart_tensor)
 
 add_library(buffer OBJECT buffer.cpp)
 target_include_directories(buffer PRIVATE ${AMDINFER_INCLUDE_DIRS})

--- a/src/amdinfer/buffers/buffer.cpp
+++ b/src/amdinfer/buffers/buffer.cpp
@@ -24,9 +24,13 @@
 
 namespace amdinfer {
 
+Buffer::Buffer(MemoryAllocators allocator) : allocator_(allocator) {}
+
 size_t Buffer::write(void* data, size_t offset, size_t size) {
   std::memcpy(this->data(offset), data, size);
   return offset + size;
 }
+
+MemoryAllocators Buffer::getAllocator() const { return allocator_; }
 
 }  // namespace amdinfer

--- a/src/amdinfer/buffers/buffer.hpp
+++ b/src/amdinfer/buffers/buffer.hpp
@@ -26,6 +26,8 @@
 #include <cstring>  // for memcpy
 #include <string>   // for string
 
+#include "amdinfer/core/memory_pool/memory_allocator.hpp"
+
 // IWYU is creating a cycle with adding/removing this header
 // IWYU pragma: no_include <algorithm>
 
@@ -37,6 +39,8 @@ namespace amdinfer {
  */
 class Buffer {
  public:
+  explicit Buffer(MemoryAllocators allocator);
+
   /// Destroy the Buffer object
   virtual ~Buffer() = default;
 
@@ -86,6 +90,11 @@ class Buffer {
       return this->write(&value, offset, sizeof(T));
     }
   }
+
+  MemoryAllocators getAllocator() const;
+
+ private:
+  MemoryAllocators allocator_;
 };
 
 }  // namespace amdinfer

--- a/src/amdinfer/buffers/cpu.cpp
+++ b/src/amdinfer/buffers/cpu.cpp
@@ -26,7 +26,7 @@
 namespace amdinfer {
 
 CpuBuffer::CpuBuffer(void* data, MemoryAllocators allocator)
-  : allocator_(allocator), data_(static_cast<std::byte*>(data)) {}
+  : Buffer(allocator), data_(static_cast<std::byte*>(data)) {}
 
 void* CpuBuffer::data(size_t offset) { return data_ + offset; }
 

--- a/src/amdinfer/buffers/cpu.hpp
+++ b/src/amdinfer/buffers/cpu.hpp
@@ -31,7 +31,7 @@
 namespace amdinfer {
 
 /**
- * @brief VectorBuffer uses vectors for storing data
+ * @brief CpuBuffer uses vectors for storing data
  *
  */
 class CpuBuffer : public Buffer {

--- a/src/amdinfer/buffers/vart_tensor.cpp
+++ b/src/amdinfer/buffers/vart_tensor.cpp
@@ -53,4 +53,6 @@ void* VartTensorBuffer::data(size_t offset) {
   return reinterpret_cast<void*>(data_->data(shape).first);
 }
 
+vart::TensorBuffer* VartTensorBuffer::getTensorBuffer() { return data_; }
+
 }  // namespace amdinfer

--- a/src/amdinfer/buffers/vart_tensor.cpp
+++ b/src/amdinfer/buffers/vart_tensor.cpp
@@ -1,0 +1,56 @@
+// Copyright 2023 Advanced Micro Devices, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file
+ * @brief Implements the VartTensorBuffer class
+ */
+
+#include "amdinfer/buffers/vart_tensor.hpp"
+
+#include <vart/tensor_buffer.hpp>
+#include <vector>                 // for vector
+#include <xir/tensor/tensor.hpp>  // for Tensor
+
+namespace amdinfer {
+
+VartTensorBuffer::VartTensorBuffer(void* data, MemoryAllocators allocator)
+  : Buffer(allocator), data_(static_cast<vart::TensorBuffer*>(data)) {}
+
+void* VartTensorBuffer::data(size_t offset) {
+  const auto* tensor = data_->get_tensor();
+
+  // Some DPUs need a shape argument to data() to get the data properly.
+  // This argument should be the same size as the tensor (by default,
+  // [batch, h, w, c]). This first argument is the batch index. The other
+  // indices should be zero to get the start of the batch
+  std::vector<int> shape(tensor->get_shape().size(), 0);
+
+  auto dims = tensor->get_shape();
+  auto size = tensor->get_shape().size();
+
+  // convert the offset to a shape based on the tensor shape
+  for (auto k = 0U; k < size; k++) {
+    auto stride = 1;
+    for (auto m = k + 1; m < size; m++) {
+      stride *= dims[m];
+    }
+    shape[k] = static_cast<int>(offset / stride);
+    offset -= shape[k] * stride;
+  }
+
+  return reinterpret_cast<void*>(data_->data(shape).first);
+}
+
+}  // namespace amdinfer

--- a/src/amdinfer/buffers/vart_tensor.hpp
+++ b/src/amdinfer/buffers/vart_tensor.hpp
@@ -14,28 +14,23 @@
 
 /**
  * @file
- * @brief
+ * @brief Defines the VartTensorBuffer class
  */
 
-#ifndef GUARD_AMDINFER_BUFFERS_CPU
-#define GUARD_AMDINFER_BUFFERS_CPU
+#ifndef GUARD_AMDINFER_BUFFERS_VART_TENSOR
+#define GUARD_AMDINFER_BUFFERS_VART_TENSOR
 
-#include <cstddef>  // for size_t, byte
-#include <vector>   // for vector
+#include <cstddef>  // for size_t
 
-#include "amdinfer/buffers/buffer.hpp"   // IWYU pragma: export
-#include "amdinfer/core/data_types.hpp"  // for DataType
-#include "amdinfer/util/queue.hpp"       // for BufferPtrsQueue
+#include "amdinfer/buffers/buffer.hpp"
+
+namespace vart {
+class TensorBuffer;
+}  // namespace vart
 
 namespace amdinfer {
 
-enum class MemoryAllocators;
-
-/**
- * @brief CpuBuffer uses vectors for storing data
- *
- */
-class CpuBuffer : public Buffer {
+class VartTensorBuffer : public Buffer {
  public:
   /**
    * @brief Construct a new Vector Buffer object
@@ -43,7 +38,7 @@ class CpuBuffer : public Buffer {
    * @param elements number of elements to store
    * @param data_type type of element to store
    */
-  CpuBuffer(void* data, MemoryAllocators allocator);
+  VartTensorBuffer(void* data, MemoryAllocators allocator);
 
   /**
    * @brief Returns a pointer to the underlying data
@@ -53,9 +48,9 @@ class CpuBuffer : public Buffer {
   void* data(size_t offset) override;
 
  private:
-  std::byte* data_;
+  vart::TensorBuffer* data_;
 };
 
 }  // namespace amdinfer
 
-#endif  // GUARD_AMDINFER_BUFFERS_CPU
+#endif  // GUARD_AMDINFER_BUFFERS_VART_TENSOR

--- a/src/amdinfer/buffers/vart_tensor.hpp
+++ b/src/amdinfer/buffers/vart_tensor.hpp
@@ -47,6 +47,8 @@ class VartTensorBuffer : public Buffer {
    */
   void* data(size_t offset) override;
 
+  vart::TensorBuffer* getTensorBuffer();
+
  private:
   vart::TensorBuffer* data_;
 };

--- a/src/amdinfer/clients/native.cpp
+++ b/src/amdinfer/clients/native.cpp
@@ -26,6 +26,7 @@
 #include <string>   // for string
 #include <utility>  // for move
 
+#include "amdinfer/buffers/buffer.hpp"   // for BufferPtr
 #include "amdinfer/build_options.hpp"    // for AMDINFER_ENABLE_TRACING
 #include "amdinfer/core/exceptions.hpp"  // for invalid_argument
 #include "amdinfer/core/parameters.hpp"  // for ParameterMap
@@ -89,7 +90,7 @@ InferenceRequestPtr getRequest(const InferenceRequest& req,
   int i = 0;
   for (const auto& input : inputs) {
     auto size = input.getSize() * input.getDatatype().size();
-    auto buffer = pool->get({MemoryAllocators::Cpu}, size);
+    auto buffer = pool->get({MemoryAllocators::Cpu}, input, 1);
     buffer->write(input.getData(), 0, size);
     request->setInputTensorData(i, buffer->data(0));
     i++;

--- a/src/amdinfer/core/data_types_internal.cpp
+++ b/src/amdinfer/core/data_types_internal.cpp
@@ -92,13 +92,13 @@ xir::DataType mapTypeToXir(DataType type) {
     case DataType::Uint16:
     case DataType::Uint32:
     case DataType::Uint64:
-      retval.type = xir::DataType::UINT;
+      retval.type = xir::DataType::XUINT;
       break;
     case DataType::Int8:
     case DataType::Int16:
     case DataType::Int32:
     case DataType::Int64:
-      retval.type = xir::DataType::INT;
+      retval.type = xir::DataType::XINT;
       break;
     // case DataType::Fp16 fall through to default handler
     case DataType::Fp32:

--- a/src/amdinfer/core/memory_pool/CMakeLists.txt
+++ b/src/amdinfer/core/memory_pool/CMakeLists.txt
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set(targets cpu_allocator pool)
+set(targets cpu_allocator vart_tensor_allocator pool)
 
 foreach(target ${targets})
   add_library(${target} OBJECT ${target}.cpp)

--- a/src/amdinfer/core/memory_pool/CMakeLists.txt
+++ b/src/amdinfer/core/memory_pool/CMakeLists.txt
@@ -13,7 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set(targets cpu_allocator vart_tensor_allocator pool)
+set(targets cpu_allocator pool)
+
+if(${AMDINFER_ENABLE_VITIS})
+  list(APPEND targets vart_tensor_allocator)
+endif()
 
 foreach(target ${targets})
   add_library(${target} OBJECT ${target}.cpp)
@@ -22,6 +26,12 @@ foreach(target ${targets})
 
   list(APPEND MEMORY_POOL_OBJS $<TARGET_OBJECTS:${target}>)
 endforeach()
+
+if(${AMDINFER_ENABLE_VITIS})
+  target_link_libraries(
+    vart_tensor_allocator INTERFACE vart::buffer-object data_types_internal
+  )
+endif()
 
 add_library(memory_pool STATIC ${MEMORY_POOL_OBJS})
 target_link_libraries(memory_pool INTERFACE ${targets})

--- a/src/amdinfer/core/memory_pool/cpu_allocator.cpp
+++ b/src/amdinfer/core/memory_pool/cpu_allocator.cpp
@@ -102,22 +102,29 @@ void CpuAllocator::put(const void* address) {
   }
 
   // if the previous is free and from the same block, merge the two
-  if (auto prev = std::prev(found);
-      prev->block_id == found->block_id && prev->free) {
-    prev->size += found->size;
-    headers_.erase(found);
-    found = prev;
+  if (found != std::begin(headers_)) {
+    auto prev = std::prev(found);
+    if (prev->block_id == found->block_id && prev->free) {
+      prev->size += found->size;
+      headers_.erase(found);
+      found = prev;
+    }
   }
 
   // if the next is free and from the same block, merge the two
-  if (auto next = std::next(found);
-      next->block_id == found->block_id && next->free) {
-    next->size += found->size;
-    next->address = found->address;
-    headers_.erase(found);
+  if (found != std::prev(std::end(headers_))) {
+    auto next = std::next(found);
+    if (next->block_id == found->block_id && next->free) {
+      next->size += found->size;
+      next->address = found->address;
+      headers_.erase(found);
+    } else {
+      found->free = true;
+    }
   } else {
     found->free = true;
   }
+
   // std::cout << "Freed memory\n";
 }
 

--- a/src/amdinfer/core/memory_pool/cpu_allocator.cpp
+++ b/src/amdinfer/core/memory_pool/cpu_allocator.cpp
@@ -25,13 +25,17 @@
 
 #include "amdinfer/buffers/cpu.hpp"
 #include "amdinfer/core/exceptions.hpp"
+#include "amdinfer/core/predict_api.hpp"
 
 namespace amdinfer {
 
 CpuAllocator::CpuAllocator(size_t block_size, size_t max_allocate)
   : max_allocate_(max_allocate), block_size_(block_size) {}
 
-BufferPtr CpuAllocator::get(size_t size) {
+BufferPtr CpuAllocator::get(const InferenceRequestInput& tensor,
+                            size_t batch_size) {
+  auto size = tensor.getSize() * tensor.getDatatype().size() * batch_size;
+
   const std::lock_guard lock{mutex_};
   auto best = headers_.end();
   const auto end = headers_.end();

--- a/src/amdinfer/core/memory_pool/cpu_allocator.hpp
+++ b/src/amdinfer/core/memory_pool/cpu_allocator.hpp
@@ -48,7 +48,7 @@ class CpuAllocator : public MemoryAllocator {
   size_t block_id_ = 0;
   std::mutex mutex_;
   std::list<MemoryHeader> headers_;
-  std::vector<std::vector<std::byte>> data_;
+  std::list<std::vector<std::byte>> data_;
 };
 
 }  // namespace amdinfer

--- a/src/amdinfer/core/memory_pool/cpu_allocator.hpp
+++ b/src/amdinfer/core/memory_pool/cpu_allocator.hpp
@@ -35,7 +35,8 @@ class CpuAllocator : public MemoryAllocator {
  public:
   explicit CpuAllocator(size_t block_size, size_t max_allocated = -1);
 
-  [[nodiscard]] BufferPtr get(size_t size) override;
+  [[nodiscard]] BufferPtr get(const InferenceRequestInput& tensor,
+                              size_t batch_size) override;
   void put(const void* address) override;
 
   // void free(const void* address);

--- a/src/amdinfer/core/memory_pool/cpu_allocator.hpp
+++ b/src/amdinfer/core/memory_pool/cpu_allocator.hpp
@@ -35,7 +35,7 @@ class CpuAllocator : public MemoryAllocator {
  public:
   explicit CpuAllocator(size_t block_size, size_t max_allocated = -1);
 
-  [[nodiscard]] void* get(size_t size) override;
+  [[nodiscard]] BufferPtr get(size_t size) override;
   void put(const void* address) override;
 
   // void free(const void* address);

--- a/src/amdinfer/core/memory_pool/memory_allocator.hpp
+++ b/src/amdinfer/core/memory_pool/memory_allocator.hpp
@@ -41,7 +41,8 @@ class MemoryAllocator {
   virtual ~MemoryAllocator() = default;
 
   // these methods are thread-safe
-  [[nodiscard]] virtual BufferPtr get(size_t size) = 0;
+  [[nodiscard]] virtual BufferPtr get(const InferenceRequestInput& tensor,
+                                      size_t batch_size) = 0;
   virtual void put(const void* address) = 0;
 };
 

--- a/src/amdinfer/core/memory_pool/memory_allocator.hpp
+++ b/src/amdinfer/core/memory_pool/memory_allocator.hpp
@@ -22,6 +22,8 @@
 
 #include <cstddef>  // for size_t
 
+#include "amdinfer/declarations.hpp"
+
 namespace amdinfer {
 
 struct MemoryHeader {
@@ -39,7 +41,7 @@ class MemoryAllocator {
   virtual ~MemoryAllocator() = default;
 
   // these methods are thread-safe
-  [[nodiscard]] virtual void* get(size_t size) = 0;
+  [[nodiscard]] virtual BufferPtr get(size_t size) = 0;
   virtual void put(const void* address) = 0;
 };
 

--- a/src/amdinfer/core/memory_pool/memory_allocator.hpp
+++ b/src/amdinfer/core/memory_pool/memory_allocator.hpp
@@ -26,6 +26,8 @@
 
 namespace amdinfer {
 
+enum class MemoryAllocators { Cpu, VartTensor };
+
 struct MemoryHeader {
   std::byte* address;
   bool free;

--- a/src/amdinfer/core/memory_pool/pool.cpp
+++ b/src/amdinfer/core/memory_pool/pool.cpp
@@ -35,14 +35,10 @@ MemoryPool::MemoryPool() {
 std::unique_ptr<Buffer> MemoryPool::get(
   const std::vector<MemoryAllocators>& allocators, size_t size) const {
   for (const auto& allocator : allocators) {
-    void* address = nullptr;
     try {
-      address = allocators_.at(allocator)->get(size);
+      return allocators_.at(allocator)->get(size);
     } catch (const runtime_error&) {
       continue;
-    }
-    if (address != nullptr) {
-      return std::make_unique<CpuBuffer>(address, allocator);
     }
   }
   throw runtime_error("Memory could not be allocated");

--- a/src/amdinfer/core/memory_pool/pool.cpp
+++ b/src/amdinfer/core/memory_pool/pool.cpp
@@ -22,6 +22,7 @@
 #include "amdinfer/buffers/cpu.hpp"
 #include "amdinfer/core/exceptions.hpp"
 #include "amdinfer/core/memory_pool/cpu_allocator.hpp"
+#include "amdinfer/core/memory_pool/vart_tensor_allocator.hpp"
 
 namespace amdinfer {
 
@@ -30,6 +31,8 @@ const size_t kDefaultCpuBlockSize = 1'048'576;  // arbitrarily 1MiB
 MemoryPool::MemoryPool() {
   allocators_.try_emplace(MemoryAllocators::Cpu,
                           std::make_unique<CpuAllocator>(kDefaultCpuBlockSize));
+  allocators_.try_emplace(MemoryAllocators::VartTensor,
+                          std::make_unique<VartTensorAllocator>());
 }
 
 std::unique_ptr<Buffer> MemoryPool::get(
@@ -46,9 +49,8 @@ std::unique_ptr<Buffer> MemoryPool::get(
 }
 
 void MemoryPool::put(std::unique_ptr<Buffer> memory) const {
-  auto* buffer = dynamic_cast<CpuBuffer*>(memory.get());
-  const auto allocator = buffer->getAllocator();
-  const auto* address = buffer->data(0);
+  const auto allocator = memory->getAllocator();
+  const auto* address = memory->data(0);
   allocators_.at(allocator)->put(address);
 }
 

--- a/src/amdinfer/core/memory_pool/pool.cpp
+++ b/src/amdinfer/core/memory_pool/pool.cpp
@@ -31,8 +31,10 @@ const size_t kDefaultCpuBlockSize = 1'048'576;  // arbitrarily 1MiB
 MemoryPool::MemoryPool() {
   allocators_.try_emplace(MemoryAllocators::Cpu,
                           std::make_unique<CpuAllocator>(kDefaultCpuBlockSize));
+#ifdef AMDINFER_ENABLE_VITIS
   allocators_.try_emplace(MemoryAllocators::VartTensor,
                           std::make_unique<VartTensorAllocator>());
+#endif
 }
 
 std::unique_ptr<Buffer> MemoryPool::get(

--- a/src/amdinfer/core/memory_pool/pool.cpp
+++ b/src/amdinfer/core/memory_pool/pool.cpp
@@ -33,10 +33,11 @@ MemoryPool::MemoryPool() {
 }
 
 std::unique_ptr<Buffer> MemoryPool::get(
-  const std::vector<MemoryAllocators>& allocators, size_t size) const {
+  const std::vector<MemoryAllocators>& allocators,
+  const InferenceRequestInput& tensor, size_t batch_size) const {
   for (const auto& allocator : allocators) {
     try {
-      return allocators_.at(allocator)->get(size);
+      return allocators_.at(allocator)->get(tensor, batch_size);
     } catch (const runtime_error&) {
       continue;
     }

--- a/src/amdinfer/core/memory_pool/pool.hpp
+++ b/src/amdinfer/core/memory_pool/pool.hpp
@@ -25,9 +25,9 @@
 #include <unordered_map>
 #include <vector>
 
-#include "amdinfer/buffers/buffer.hpp"
 #include "amdinfer/build_options.hpp"
 #include "amdinfer/core/memory_pool/memory_allocator.hpp"
+#include "amdinfer/declarations.hpp"
 
 namespace amdinfer {
 
@@ -40,7 +40,8 @@ class MemoryPool {
   MemoryPool();
 
   std::unique_ptr<Buffer> get(const std::vector<MemoryAllocators>& allocators,
-                              size_t size) const;
+                              const InferenceRequestInput& tensor,
+                              size_t batch_size) const;
   void put(std::unique_ptr<Buffer> memory) const;
 
  private:

--- a/src/amdinfer/core/memory_pool/pool.hpp
+++ b/src/amdinfer/core/memory_pool/pool.hpp
@@ -31,10 +31,6 @@
 
 namespace amdinfer {
 
-enum class MemoryAllocators { Cpu };
-
-using Memory = std::pair<MemoryAllocators, void*>;
-
 class MemoryPool {
  public:
   MemoryPool();

--- a/src/amdinfer/core/memory_pool/vart_tensor_allocator.cpp
+++ b/src/amdinfer/core/memory_pool/vart_tensor_allocator.cpp
@@ -1,0 +1,125 @@
+// Copyright 2023 Advanced Micro Devices, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file
+ * @brief
+ */
+
+#include "amdinfer/core/memory_pool/vart_tensor_allocator.hpp"
+
+#include <cassert>
+#include <iostream>
+#include <vector>
+#include <xir/util/data_type.hpp>  // for DataType
+
+#include "amdinfer/buffers/vart_tensor.hpp"
+#include "amdinfer/core/exceptions.hpp"
+#include "amdinfer/core/predict_api.hpp"
+
+namespace amdinfer {
+
+xir::DataType mapTypeToXir(DataType type) {
+  xir::DataType retval;
+  auto bit_width = static_cast<int32_t>(type.size()) * 8;
+  switch (type) {
+    case DataType::Bool:
+    case DataType::Uint8:
+    case DataType::Uint16:
+    case DataType::Uint32:
+    case DataType::Uint64:
+      retval.type = xir::DataType::UINT;
+      break;
+    case DataType::Int8:
+    case DataType::Int16:
+    case DataType::Int32:
+    case DataType::Int64:
+      retval.type = xir::DataType::INT;
+      break;
+    // case DataType::FP16 fall through to default handler
+    case DataType::Fp32:
+    case DataType::Fp64:
+      retval.type = xir::DataType::FLOAT;
+      break;
+    default:
+      throw invalid_argument("Unsupported type conversion to XIR");
+  }
+  retval.bit_width = bit_width;
+  return retval;
+}
+
+VartTensorAllocator::VartTensorAllocator(size_t max_allocate)
+  : max_allocate_(max_allocate) {}
+
+BufferPtr VartTensorAllocator::get(const InferenceRequestInput& tensor,
+                                   size_t batch_size) {
+  const auto& name = tensor.getName();
+  const auto& shape = tensor.getShape();
+  const auto datatype = tensor.getDatatype();
+
+  const std::lock_guard lock{mutex_};
+  auto found = headers_.end();
+  const auto end = headers_.end();
+  for (auto it = headers_.begin(); it != end; it++) {
+    if (it->free && it->name == name && it->shape == shape &&
+        it->datatype == datatype && it->batch_size == batch_size) {
+      found = it;
+      break;
+    }
+  }
+
+  if (found != end) {
+    found->free = false;
+    return std::make_unique<VartTensorBuffer>(found->address,
+                                              MemoryAllocators::VartTensor);
+  }
+
+  auto size_to_allocate = tensor.getSize() * datatype.size() * batch_size;
+  if (allocated_ + size_to_allocate > max_allocate_) {
+    throw runtime_error("Too much requested");
+  }
+
+  auto xir_type = mapTypeToXir(datatype);
+  std::vector<int> xir_shape{shape.begin(), shape.end()};
+  tensors_.emplace_back(xir::Tensor::create(name, xir_shape, xir_type));
+  buffers_.emplace_back(tensors_.back().get());
+
+  allocated_ += size_to_allocate;
+
+  auto* retval = reinterpret_cast<std::byte*>(&(buffers_.back()));
+
+  headers_.emplace_back(retval, false, name, shape, datatype, batch_size);
+
+  return std::make_unique<VartTensorBuffer>(retval,
+                                            MemoryAllocators::VartTensor);
+}
+
+void VartTensorAllocator::put(const void* address) {
+  const std::lock_guard lock{mutex_};
+  const auto end = headers_.end();
+  auto found = headers_.end();
+  for (auto it = headers_.begin(); it != end; it++) {
+    if (it->address == address) {
+      found->free = true;
+      // std::cout << "Freed memory\n";
+      return;
+    }
+  }
+
+  if (found == end) {
+    throw runtime_error("Address not found");
+  }
+}
+
+}  // namespace amdinfer

--- a/src/amdinfer/core/memory_pool/vart_tensor_allocator.cpp
+++ b/src/amdinfer/core/memory_pool/vart_tensor_allocator.cpp
@@ -25,39 +25,11 @@
 #include <xir/util/data_type.hpp>  // for DataType
 
 #include "amdinfer/buffers/vart_tensor.hpp"
+#include "amdinfer/core/data_types_internal.hpp"
 #include "amdinfer/core/exceptions.hpp"
 #include "amdinfer/core/predict_api.hpp"
 
 namespace amdinfer {
-
-xir::DataType mapTypeToXir(DataType type) {
-  xir::DataType retval;
-  auto bit_width = static_cast<int32_t>(type.size()) * 8;
-  switch (type) {
-    case DataType::Bool:
-    case DataType::Uint8:
-    case DataType::Uint16:
-    case DataType::Uint32:
-    case DataType::Uint64:
-      retval.type = xir::DataType::UINT;
-      break;
-    case DataType::Int8:
-    case DataType::Int16:
-    case DataType::Int32:
-    case DataType::Int64:
-      retval.type = xir::DataType::INT;
-      break;
-    // case DataType::FP16 fall through to default handler
-    case DataType::Fp32:
-    case DataType::Fp64:
-      retval.type = xir::DataType::FLOAT;
-      break;
-    default:
-      throw invalid_argument("Unsupported type conversion to XIR");
-  }
-  retval.bit_width = bit_width;
-  return retval;
-}
 
 VartTensorAllocator::VartTensorAllocator(size_t max_allocate)
   : max_allocate_(max_allocate) {}

--- a/src/amdinfer/core/memory_pool/vart_tensor_allocator.hpp
+++ b/src/amdinfer/core/memory_pool/vart_tensor_allocator.hpp
@@ -1,0 +1,77 @@
+// Copyright 2023 Advanced Micro Devices, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file
+ * @brief
+ */
+
+#ifndef GUARD_AMDINFER_CORE_MEMORY_POOL_VART_TENSOR_ALLOCATOR
+#define GUARD_AMDINFER_CORE_MEMORY_POOL_VART_TENSOR_ALLOCATOR
+
+#include <cstddef>
+#include <list>
+#include <mutex>
+#include <vart/experimental/runner_helper.hpp>  // for CpuFlatTensorBufferOwned
+#include <vector>
+#include <xir/tensor/tensor.hpp>  // for Tensor
+
+#include "amdinfer/core/memory_pool/memory_allocator.hpp"
+#include "amdinfer/core/predict_api.hpp"
+
+namespace amdinfer {
+
+struct VartTensorHeader {
+  std::byte* address;
+  bool free;
+
+  std::string name;
+  std::vector<uint64_t> shape;
+  DataType datatype;
+  size_t batch_size;
+
+  VartTensorHeader(std::byte* address, bool free, const std::string& name,
+                   const std::vector<uint64_t>& shape, DataType datatype,
+                   size_t batch_size)
+    : address(address),
+      free(free),
+      name(name),
+      shape(shape),
+      datatype(datatype),
+      batch_size(batch_size) {}
+};
+
+class VartTensorAllocator : public MemoryAllocator {
+ public:
+  explicit VartTensorAllocator(size_t max_allocated = -1);
+
+  [[nodiscard]] BufferPtr get(const InferenceRequestInput& tensor,
+                              size_t batch_size) override;
+  void put(const void* address) override;
+
+  // void free(const void* address);
+
+ private:
+  size_t allocated_ = 0;
+  size_t max_allocate_;
+  std::mutex mutex_;
+
+  std::list<VartTensorHeader> headers_;
+  std::vector<std::unique_ptr<xir::Tensor>> tensors_;
+  std::vector<vart::CpuFlatTensorBufferOwned> buffers_;
+};
+
+}  // namespace amdinfer
+
+#endif  // GUARD_AMDINFER_CORE_MEMORY_POOL_VART_TENSOR_ALLOCATOR

--- a/src/amdinfer/core/memory_pool/vart_tensor_allocator.hpp
+++ b/src/amdinfer/core/memory_pool/vart_tensor_allocator.hpp
@@ -68,8 +68,8 @@ class VartTensorAllocator : public MemoryAllocator {
   std::mutex mutex_;
 
   std::list<VartTensorHeader> headers_;
-  std::vector<std::unique_ptr<xir::Tensor>> tensors_;
-  std::vector<vart::CpuFlatTensorBufferOwned> buffers_;
+  std::list<std::unique_ptr<xir::Tensor>> tensors_;
+  std::list<vart::CpuFlatTensorBufferOwned> buffers_;
 };
 
 }  // namespace amdinfer

--- a/src/amdinfer/servers/grpc_server.cpp
+++ b/src/amdinfer/servers/grpc_server.cpp
@@ -317,8 +317,7 @@ InferenceRequestInput getInput(
   input.setParameters(mapProtoToParameters(req.parameters()));
 
   auto size = input.getSize();
-  auto buffer =
-    pool->get({MemoryAllocators::Cpu}, size * input.getDatatype().size());
+  auto buffer = pool->get({MemoryAllocators::Cpu}, input, 1);
   input.setData(buffer->data(0));
   // auto* dest = static_cast<std::byte*>(input_buffer->data(offset));
   AMDINFER_LOG_TRACE(observer.logger, "Writing " + std::to_string(size) +

--- a/src/amdinfer/servers/http_server.cpp
+++ b/src/amdinfer/servers/http_server.cpp
@@ -32,6 +32,7 @@
 #include <utility>        // for move
 #include <vector>         // for vector
 
+#include "amdinfer/buffers/buffer.hpp"         // for BufferPtr
 #include "amdinfer/build_options.hpp"          // for AMDINFER_ENABLE_TRACING
 #include "amdinfer/clients/http_internal.hpp"  // for propagate, errorHtt...
 #include "amdinfer/core/exceptions.hpp"        // for runtime_error, inva...
@@ -367,8 +368,7 @@ InferenceRequestInput getInput(const Json::Value &json,
     input.setParameters(std::make_unique<ParameterMap>());
   }
 
-  auto size = input.getDatatype().size() * util::containerProduct(shape_vector);
-  auto buffer = pool->get({MemoryAllocators::Cpu}, size);
+  auto buffer = pool->get({MemoryAllocators::Cpu}, input, 1);
   if (!json.isMember("data")) {
     throw invalid_argument("No 'data' key present in request input");
   }

--- a/tests/performance/batching/CMakeLists.txt
+++ b/tests/performance/batching/CMakeLists.txt
@@ -21,7 +21,7 @@ list(
     "$<TARGET_OBJECTS:batcher>~fake_observation\
       ~$<TARGET_OBJECTS:fake_worker_info_buffers_finite>~predict_api~parameters\
       ~data_types\~$<TARGET_OBJECTS:softBatcher>~cpuBuffer~buffer~memory_pool\
-      ~batch~timer"
+      ~data_types_internal~vart_tensorBuffer~batch~timer~vart::runner"
 )
 
 amdinfer_add_benchmarks("${tests}" "${tests_libs}")

--- a/tests/performance/batching/benchmark_soft.cpp
+++ b/tests/performance/batching/benchmark_soft.cpp
@@ -31,6 +31,7 @@
 #include <vector>    // for vector
 
 #include "amdinfer/batching/soft.hpp"          // for BatchPtr, SoftBatcher
+#include "amdinfer/buffers/buffer.hpp"         // for BufferPtr
 #include "amdinfer/core/data_types.hpp"        // for DataType, DataType::U...
 #include "amdinfer/core/memory_pool/pool.hpp"  // for MemoryPool
 #include "amdinfer/core/parameters.hpp"        // for ParameterMap

--- a/tests/unit/batching/CMakeLists.txt
+++ b/tests/unit/batching/CMakeLists.txt
@@ -20,11 +20,12 @@ list(
     tests_libs
     "$<TARGET_OBJECTS:batcher>~fake_observation~\
       $<TARGET_OBJECTS:fake_worker_info_buffers_infinite>~predict_api~\
-      parameters~data_types~$<TARGET_OBJECTS:softBatcher>~timer~memory_pool~batch~cpuBuffer~buffer"
+      parameters~data_types~$<TARGET_OBJECTS:softBatcher>~timer~memory_pool~\
+      batch~cpuBuffer~buffer~vart::runner~data_types_internal~vart_tensorBuffer"
     "$<TARGET_OBJECTS:batcher>~fake_observation~\
       $<TARGET_OBJECTS:fake_worker_info_buffers_finite>~predict_api~data_types~\
       parameters~$<TARGET_OBJECTS:softBatcher>~cpuBuffer~buffer~\
-      timer~memory_pool~batch"
+      timer~memory_pool~batch~vart::runner~data_types_internal~vart_tensorBuffer"
 )
 
 amdinfer_add_unit_tests("${tests}" "${tests_libs}")

--- a/tests/unit/batching/test_soft_batching.cpp
+++ b/tests/unit/batching/test_soft_batching.cpp
@@ -111,7 +111,9 @@ class UnitSoftBatcherFixture : public testing::TestWithParam<BatchConfig> {
 
     this->batcher_->start({MemoryAllocators::Cpu});
 
-    buffer_ = pool_.get({MemoryAllocators::Cpu}, data_size);
+    InferenceRequestInput input{nullptr, data_shape_, DataType::Uint8};
+
+    buffer_ = pool_.get({MemoryAllocators::Cpu}, input, data_size);
 
     auto* data = static_cast<uint8_t*>(buffer_->data(0));
 

--- a/tests/unit/core/memory_pool/CMakeLists.txt
+++ b/tests/unit/core/memory_pool/CMakeLists.txt
@@ -14,9 +14,12 @@
 
 list(APPEND tests cpu_allocator pool)
 
-list(APPEND tests_libs
-            "cpu_allocator~buffer~cpuBuffer~predict_api~data_types~parameters"
-            "memory_pool~buffer~cpuBuffer~predict_api~data_types~parameters"
+list(
+  APPEND tests_libs
+         "cpu_allocator~buffer~cpuBuffer~predict_api~data_types~parameters~\
+           vart::runner~data_types_internal~vart_tensorBuffer"
+         "memory_pool~buffer~cpuBuffer~predict_api~data_types~parameters~\
+           vart::runner~data_types_internal~vart_tensorBuffer"
 )
 
 amdinfer_add_unit_tests("${tests}" "${tests_libs}")

--- a/tests/unit/core/memory_pool/CMakeLists.txt
+++ b/tests/unit/core/memory_pool/CMakeLists.txt
@@ -14,6 +14,8 @@
 
 list(APPEND tests cpu_allocator pool)
 
-list(APPEND tests_libs "cpu_allocator" "memory_pool~buffer~cpuBuffer")
+list(APPEND tests_libs "cpu_allocator~buffer~cpuBuffer"
+            "memory_pool~buffer~cpuBuffer"
+)
 
 amdinfer_add_unit_tests("${tests}" "${tests_libs}")

--- a/tests/unit/core/memory_pool/CMakeLists.txt
+++ b/tests/unit/core/memory_pool/CMakeLists.txt
@@ -14,8 +14,9 @@
 
 list(APPEND tests cpu_allocator pool)
 
-list(APPEND tests_libs "cpu_allocator~buffer~cpuBuffer"
-            "memory_pool~buffer~cpuBuffer"
+list(APPEND tests_libs
+            "cpu_allocator~buffer~cpuBuffer~predict_api~data_types~parameters"
+            "memory_pool~buffer~cpuBuffer~predict_api~data_types~parameters"
 )
 
 amdinfer_add_unit_tests("${tests}" "${tests_libs}")

--- a/tests/unit/core/memory_pool/test_cpu_allocator.cpp
+++ b/tests/unit/core/memory_pool/test_cpu_allocator.cpp
@@ -25,7 +25,8 @@
 #include "amdinfer/buffers/buffer.hpp"  // for BufferPtr
 #include "amdinfer/core/exceptions.hpp"
 #include "amdinfer/core/memory_pool/cpu_allocator.hpp"  // for CpuSimpl...
-#include "amdinfer/testing/gtest.hpp"  // for AssertionResult,...
+#include "amdinfer/core/predict_api.hpp"  // for InferenceRequestInput
+#include "amdinfer/testing/gtest.hpp"     // for AssertionResult,...
 
 namespace amdinfer {
 
@@ -33,8 +34,10 @@ namespace amdinfer {
 TEST(UnitCpuAllocator, Basic) {
   CpuAllocator allocator{sizeof(int)};
 
-  const auto buffer_0 = allocator.get(sizeof(int));
-  const auto buffer_1 = allocator.get(sizeof(int));
+  InferenceRequestInput input{nullptr, {1}, DataType::Int32};
+
+  const auto buffer_0 = allocator.get(input, 1);
+  const auto buffer_1 = allocator.get(input, 1);
 
   const auto* address_0 = static_cast<int*>(buffer_0->data(0));
   const auto* address_1 = static_cast<int*>(buffer_1->data(0));
@@ -47,9 +50,10 @@ TEST(UnitCpuAllocator, Basic) {
 // NOLINTNEXTLINE(cert-err58-cpp, cppcoreguidelines-owning-memory)
 TEST(UnitCpuAllocator, Correctness) {
   CpuAllocator allocator{sizeof(int) * 4, sizeof(int) * 4};
+  InferenceRequestInput input{nullptr, {1}, DataType::Int32};
 
-  const auto buffer_0 = allocator.get(sizeof(int));
-  const auto buffer_1 = allocator.get(sizeof(int));
+  const auto buffer_0 = allocator.get(input, 1);
+  const auto buffer_1 = allocator.get(input, 1);
 
   const auto* address_0 = static_cast<int*>(buffer_0->data(0));
   const auto* address_1 = static_cast<int*>(buffer_1->data(0));
@@ -57,7 +61,7 @@ TEST(UnitCpuAllocator, Correctness) {
   ASSERT_EQ(address_0 + 1, address_1);
 
   allocator.put(address_0);
-  const auto buffer_2 = allocator.get(sizeof(int));
+  const auto buffer_2 = allocator.get(input, 1);
   const auto* address_2 = static_cast<int*>(buffer_2->data(0));
 
   ASSERT_EQ(address_0, address_2);
@@ -65,7 +69,7 @@ TEST(UnitCpuAllocator, Correctness) {
   allocator.put(address_2);
   allocator.put(address_1);
 
-  const auto buffer_3 = allocator.get(sizeof(int) * 4);
+  const auto buffer_3 = allocator.get(input, 4);
   const auto* address_3 = static_cast<int*>(buffer_3->data(0));
   ASSERT_EQ(address_0, address_3);
 }
@@ -73,10 +77,11 @@ TEST(UnitCpuAllocator, Correctness) {
 // NOLINTNEXTLINE(cert-err58-cpp, cppcoreguidelines-owning-memory)
 TEST(UnitCpuAllocator, ExceedingMax) {
   CpuAllocator allocator{sizeof(int), sizeof(int)};
+  InferenceRequestInput input{nullptr, {1}, DataType::Int32};
 
-  std::ignore = allocator.get(sizeof(int));
+  std::ignore = allocator.get(input, 1);
   // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto, hicpp-avoid-goto)
-  EXPECT_THROW_CHECK(std::ignore = allocator.get(sizeof(int));
+  EXPECT_THROW_CHECK(std::ignore = allocator.get(input, 1);
                      , EXPECT_STREQ(e.what(), "Too much requested");
                      , runtime_error);
 }
@@ -84,8 +89,9 @@ TEST(UnitCpuAllocator, ExceedingMax) {
 // NOLINTNEXTLINE(cert-err58-cpp, cppcoreguidelines-owning-memory)
 TEST(UnitCpuAllocator, BadFree) {
   CpuAllocator allocator{sizeof(int)};
+  InferenceRequestInput input{nullptr, {1}, DataType::Int32};
 
-  const auto buffer_0 = allocator.get(sizeof(int));
+  const auto buffer_0 = allocator.get(input, 1);
   const auto* address_0 = static_cast<int*>(buffer_0->data(0));
   const auto* bad_address = address_0 + 1;
   // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto, hicpp-avoid-goto)

--- a/tests/unit/core/memory_pool/test_cpu_allocator.cpp
+++ b/tests/unit/core/memory_pool/test_cpu_allocator.cpp
@@ -22,6 +22,7 @@
 // #include <string>   // for string, basic_string, alloc...
 // #include <vector>   // for vector
 
+#include "amdinfer/buffers/buffer.hpp"  // for BufferPtr
 #include "amdinfer/core/exceptions.hpp"
 #include "amdinfer/core/memory_pool/cpu_allocator.hpp"  // for CpuSimpl...
 #include "amdinfer/testing/gtest.hpp"  // for AssertionResult,...
@@ -32,53 +33,61 @@ namespace amdinfer {
 TEST(UnitCpuAllocator, Basic) {
   CpuAllocator allocator{sizeof(int)};
 
-  const auto* foo = static_cast<int*>(allocator.get(sizeof(int)));
+  const auto buffer_0 = allocator.get(sizeof(int));
+  const auto buffer_1 = allocator.get(sizeof(int));
 
-  const auto* bar = static_cast<int*>(allocator.get(sizeof(int)));
-  ASSERT_NE(foo, bar);
+  const auto* address_0 = static_cast<int*>(buffer_0->data(0));
+  const auto* address_1 = static_cast<int*>(buffer_1->data(0));
+  ASSERT_NE(address_0, address_1);
 
-  allocator.put(foo);
-  allocator.put(bar);
+  allocator.put(address_0);
+  allocator.put(address_1);
 }
 
 // NOLINTNEXTLINE(cert-err58-cpp, cppcoreguidelines-owning-memory)
 TEST(UnitCpuAllocator, Correctness) {
   CpuAllocator allocator{sizeof(int) * 4, sizeof(int) * 4};
 
-  const auto* foo = static_cast<int*>(allocator.get(sizeof(int)));
-  const auto* bar = static_cast<int*>(allocator.get(sizeof(int)));
+  const auto buffer_0 = allocator.get(sizeof(int));
+  const auto buffer_1 = allocator.get(sizeof(int));
 
-  ASSERT_EQ(foo + 1, bar);
+  const auto* address_0 = static_cast<int*>(buffer_0->data(0));
+  const auto* address_1 = static_cast<int*>(buffer_1->data(0));
 
-  allocator.put(foo);
-  const auto* baz = static_cast<int*>(allocator.get(sizeof(int)));
+  ASSERT_EQ(address_0 + 1, address_1);
 
-  ASSERT_EQ(foo, baz);
+  allocator.put(address_0);
+  const auto buffer_2 = allocator.get(sizeof(int));
+  const auto* address_2 = static_cast<int*>(buffer_2->data(0));
 
-  allocator.put(baz);
-  allocator.put(bar);
+  ASSERT_EQ(address_0, address_2);
 
-  const auto* bard = static_cast<int*>(allocator.get(sizeof(int) * 4));
-  ASSERT_EQ(foo, bard);
+  allocator.put(address_2);
+  allocator.put(address_1);
+
+  const auto buffer_3 = allocator.get(sizeof(int) * 4);
+  const auto* address_3 = static_cast<int*>(buffer_3->data(0));
+  ASSERT_EQ(address_0, address_3);
 }
 
 // NOLINTNEXTLINE(cert-err58-cpp, cppcoreguidelines-owning-memory)
 TEST(UnitCpuAllocator, ExceedingMax) {
   CpuAllocator allocator{sizeof(int), sizeof(int)};
 
-  std::ignore = static_cast<int*>(allocator.get(sizeof(int)));
+  std::ignore = allocator.get(sizeof(int));
   // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto, hicpp-avoid-goto)
-  EXPECT_THROW_CHECK(
-    std::ignore = static_cast<int*>(allocator.get(sizeof(int)));
-    , EXPECT_STREQ(e.what(), "Too much requested");, runtime_error);
+  EXPECT_THROW_CHECK(std::ignore = allocator.get(sizeof(int));
+                     , EXPECT_STREQ(e.what(), "Too much requested");
+                     , runtime_error);
 }
 
 // NOLINTNEXTLINE(cert-err58-cpp, cppcoreguidelines-owning-memory)
 TEST(UnitCpuAllocator, BadFree) {
   CpuAllocator allocator{sizeof(int)};
 
-  const auto* foo = static_cast<int*>(allocator.get(sizeof(int)));
-  const auto* bad_address = foo + 1;
+  const auto buffer_0 = allocator.get(sizeof(int));
+  const auto* address_0 = static_cast<int*>(buffer_0->data(0));
+  const auto* bad_address = address_0 + 1;
   // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto, hicpp-avoid-goto)
   EXPECT_THROW_CHECK(allocator.put(bad_address);
                      , EXPECT_STREQ(e.what(), "Address not found");

--- a/tests/unit/core/memory_pool/test_pool.cpp
+++ b/tests/unit/core/memory_pool/test_pool.cpp
@@ -19,17 +19,20 @@
 
 #include <tuple>
 
+#include "amdinfer/buffers/buffer.hpp"  // for BufferPtr
 #include "amdinfer/core/exceptions.hpp"
 #include "amdinfer/core/memory_pool/pool.hpp"
-#include "amdinfer/testing/gtest.hpp"  // for AssertionResult,...
+#include "amdinfer/core/predict_api.hpp"  // for InferenceRequestInput
+#include "amdinfer/testing/gtest.hpp"     // for AssertionResult,...
 
 namespace amdinfer {
 
 // NOLINTNEXTLINE(cert-err58-cpp, cppcoreguidelines-owning-memory)
 TEST(UnitPool, Basic) {
   MemoryPool pool;
+  InferenceRequestInput input{nullptr, {1}, DataType::Int32};
 
-  auto buffer = pool.get({MemoryAllocators::Cpu}, sizeof(int));
+  auto buffer = pool.get({MemoryAllocators::Cpu}, input, 1);
 
   pool.put(std::move(buffer));
 }


### PR DESCRIPTION
# Summary of Changes

* Allow using custom memory allocation schemes

Closes #162

# Motivation

Some workers use custom classes to hold incoming data for inference. By having the batcher store the data in the right format, we can make an assumption in all workers that the incoming data will be in a compatible and valid format that's ready to use.

# Implementation

The memory pool now expects an input tensor rather than a flat numeric size to indicate how much memory to allocate. The basic allocator uses the tensor to get the flat memory space still (this logic used to be on the batcher side) but if an allocator needs the raw information about the tensor, then it can use it.

The VartTensorBuffer is back in slightly modified form and it serves the same purpose as before but now it's backed by the allocator rather than owning the memory itself.

# Notes

One gotcha is that since the allocators may be creating, freeing and merging blocks of memory, the state of the memory needs to be kept in lists so that these modifications don't invalidate existing pointers to other parts of the structure that are in use elsewhere.
