### PR TITLE
Support model chaining in modelLoad

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -32,7 +32,7 @@ Added
 * Google Benchmark for writing performance-tracking tests (:pr:`147`)
 * Custom memory storage classes in the memory pool (:pr:`166`)
 * C++ worker for executing C++ "models" (:pr:`172`)
-* Model chaining (:pr:`176`)
+* Model chaining (:pr:`176`) and loading chains from ``modelLoad`` ()
 
 Changed
 ^^^^^^^
@@ -46,6 +46,7 @@ Changed
 * Refactor inference request objects and tensors (:pr:`172`)
 * Use const references throughout for ParameterMap (:pr:`172`)
 * Update workers' ``doRun`` method signature to produce and return a batch (:pr:`176`)
+* Use TOML-based configuration files in the repository by default ()
 
 Deprecated
 ^^^^^^^^^^

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -32,6 +32,7 @@ Added
 * Google Benchmark for writing performance-tracking tests (:pr:`147`)
 * Custom memory storage classes in the memory pool (:pr:`166`)
 * C++ worker for executing C++ "models" (:pr:`172`)
+* Model chaining (:pr:`176`)
 
 Changed
 ^^^^^^^
@@ -44,6 +45,7 @@ Changed
 * Bump up to Vitis AI 3.0 (:pr:`169`)
 * Refactor inference request objects and tensors (:pr:`172`)
 * Use const references throughout for ParameterMap (:pr:`172`)
+* Update workers' ``doRun`` method signature to produce and return a batch (:pr:`176`)
 
 Deprecated
 ^^^^^^^^^^

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,6 +73,7 @@ include(CTest)
 include(SetTargetOptions)
 include(AddOption)
 include(AddTargets)
+include(TomlPlusPlus)
 
 # check requirements
 find_package(Drogon CONFIG)

--- a/cmake/AddTargets.cmake
+++ b/cmake/AddTargets.cmake
@@ -26,6 +26,7 @@ function(amdinfer_add_protobuf_target target file build_grpc)
   target_include_directories(${target} PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
   set_target_options(${target})
   protobuf_generate(TARGET ${target} LANGUAGE cpp)
+  target_link_libraries(${target} INTERFACE protobuf::libprotobuf)
   if(${build_grpc})
     protobuf_generate(
       TARGET ${target}

--- a/cmake/TomlPlusPlus.cmake
+++ b/cmake/TomlPlusPlus.cmake
@@ -1,5 +1,4 @@
-# Copyright 2021 Xilinx, Inc.
-# Copyright 2022 Advanced Micro Devices, Inc.
+# Copyright 2023 Advanced Micro Devices, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,20 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_subdirectory(memory_pool)
-
-list(
-  APPEND tests
-         inference_request_input
-         model_config
-         parameter_map
+include(FetchContent)
+FetchContent_Declare(
+  tomlplusplus GIT_REPOSITORY https://github.com/marzer/tomlplusplus.git
+  GIT_TAG v3.3.0
 )
-
-list(APPEND tests_libs "inference_request~parameters~inference_response"
-            "model_config~tensor~data_types" "parameters"
-)
-
-amdinfer_add_unit_tests("${tests}" "${tests_libs}")
-
-amdinfer_get_test_target(target model_config)
-target_link_libraries(${target} PRIVATE tomlplusplus::tomlplusplus)
+FetchContent_MakeAvailable(tomlplusplus)

--- a/docs/kserve.rst
+++ b/docs/kserve.rst
@@ -63,34 +63,32 @@ The model format for the AMD Inference Server is the following:
     /
     ├─ model_a/
     │  ├─ 1/
-    │  │  ├─ saved_model.x
-    │  ├─ config.pbtxt
+    │  │  ├─ <model>.x
+    │  ├─ <config>.toml
 
 The model name, ``model_a`` in this template, must be unique among the models loaded on a particular server.
 This name is used to name the endpoint used to make inference requests to.
-Under this directory, there must be a directory named ``1/`` containing the model file itself and a text file named ``config.pbtxt``.
-The model file must be named ``saved_model`` and the file extension depends on the type of the model.
-The ``config.pbtxt`` file contains metadata for the model.
+Under this directory, there must be a directory named ``1/`` containing the model file itself and a TOML file describing the configuration.
+This file, ``<config>.toml`` in this template, can have any name though ``config.toml`` is suggested and will be used in this documentation.
+You can also use ``.pbtxt`` format for single models as well.
+The model file can have an arbitrary name and the file extension depends on the type of the model.
+The ``config.toml`` file contains metadata for the model.
 Consider this example of an MNIST TensorFlow model:
 
-.. code-block:: text
+.. code-block:: toml
 
-    name: "mnist"
-    platform: "tensorflow_graphdef"
-    inputs [
-      {
-        name: "images_in"
-        datatype: "FP32"
-        shape: [28,28,1]
-      }
-    ]
-    outputs [
-      {
-        name: "flatten/Reshape"
-        datatype: "FP32"
-        shape: [10]
-      }
-    ]
+    name = "mnist"
+    platform = "tensorflow_graphdef"
+
+    [[inputs]]
+    name = "images_in"
+    datatype = "FP32"
+    shape = [28, 28, 1]
+
+    [[outputs]]
+    name = "flatten/Reshape"
+    datatype = "FP32"
+    shape = [10]
 
 The name must match the name of the model directory, i.e. ``model_a``.
 The platform identifies the type of the model and determines the file extension of the model file.
@@ -105,6 +103,8 @@ The supported platforms are:
     ``pytorch_torchscript``,``.pt``
     ``vitis_xmodel``,``.xmodel``
     ``onnx_onnxv1``,``.onnx``
+    ``migraphx_mxr``,``.mxr``
+    ``amdinfer_cpp``,``.so``
 
 The inputs and outputs define the list of input and output tensors for the model.
 The names of the tensors may be significant if the platform needs them to perform inference.

--- a/docs/quickstart_deployment.rst
+++ b/docs/quickstart_deployment.rst
@@ -39,16 +39,16 @@ The format of the directory is as follows:
     /
     ├─ model_a/
     │  ├─ 1/
-    │  │  ├─ saved_model.x
-    │  ├─ config.pbtxt
+    │  │  ├─ <model>.x
+    │  ├─ config.toml
     | model_b/
     |  ...
 
 The model name, ``model_a`` in this template, must be unique among the models loaded on a particular server.
 This name is used to name the endpoint used to make inference requests to.
-Under this directory, there must be a directory named ``1/`` containing the model file itself and a text file named ``config.pbtxt``.
-The model file must be named ``saved_model`` and the file extension depends on the type of the model.
-The ``config.pbtxt`` file contains metadata for the model.
+Under this directory, there must be a directory named ``1/`` containing the model file itself and a TOML file containing the metadata for the model.
+This file may be named anything but ``config.toml`` is suggested and used throughout this documentation.
+The model file can have an arbitrary name and the file extension depends on the type of the model.
 
 As an example, consider a deployment of a single ResNet50 model.
 
@@ -74,66 +74,54 @@ As an example, consider a deployment of a single ResNet50 model.
         $ mkdir -p /tmp/model_repository/resnet50/1
         $ mv ./resnet_v1_50_tf/resnet_v1_50_tf.xmodel /tmp/model_repository/resnet50/1/saved_model.xmodel
 
-For the models used here, their corresponding ``config.pbtxt`` should be placed in the chosen model repository (``/tmp/model_repository/resnet50/``):
+For the models used here, their corresponding ``config.toml`` should be placed in the chosen model repository (``/tmp/model_repository/resnet50/``):
 
 .. tabs::
 
-    .. code-tab:: text CPU
+    .. code-tab:: toml CPU
 
-        name: "resnet50"
-        platform: "tensorflow_graphdef"
-        inputs [
-            {
-                name: "input"
-                datatype: "FP32"
-                shape: [224,224,3]
-            }
-        ]
-        outputs [
-            {
-                name: "resnet_v1_50/predictions/Reshape_1"
-                datatype: "FP32"
-                shape: [1000]
-            }
-        ]
+        name = "resnet50"
+        platform = "tensorflow_graphdef"
+
+        [[inputs]]
+        name = "input"
+        datatype = "FP32"
+        shape = [224, 224, 3]
+
+        [[outputs]]
+        name = "resnet_v1_50/predictions/Reshape_1"
+        datatype = "FP32"
+        shape = [1000]
 
     .. code-tab:: text GPU
 
-        name: "resnet50"
-        platform: "onnx_onnxv1"
-        inputs [
-            {
-                name: "input"
-                datatype: "FP32"
-                shape: [224,224,3]
-            }
-        ]
-        outputs [
-            {
-                name: "output"
-                datatype: "FP32"
-                shape: [1000]
-            }
-        ]
+        name = "resnet50"
+        platform = "onnx_onnxv1"
+
+        [[inputs]]
+        name = "input"
+        datatype = "FP32"
+        shape = [224, 224, 3]
+
+        [[outputs]]
+        name = "output"
+        datatype = "FP32"
+        shape = [1000]
 
     .. code-tab:: console FPGA
 
-        name: "resnet50"
-        platform: "vitis_xmodel"
-        inputs [
-            {
-                name: "input"
-                datatype: "INT8"
-                shape: [224,224,3]
-            }
-        ]
-        outputs [
-            {
-                name: "output"
-                datatype: "INT8"
-                shape: [1000]
-            }
-        ]
+        name = "resnet50"
+        platform = "vitis_xmodel"
+
+        [[inputs]]
+        name = "input"
+        datatype = "INT8"
+        shape = [224, 224, 3]
+
+        [[outputs]]
+        name = "output"
+        datatype = "INT8"
+        shape = [1000]
 
 The name must match the name of the model directory.
 The platform identifies the type of the model and determines the file extension of the model file.
@@ -148,6 +136,8 @@ The supported platforms are:
     ``pytorch_torchscript``,``.pt``
     ``vitis_xmodel``,``.xmodel``
     ``onnx_onnxv1``,``.onnx``
+    ``migraphx_mxr``,``.mxr``
+    ``amdinfer_cpp``,``.so``
 
 The inputs and outputs define the list of input and output tensors for the model.
 The names of the tensors may be significant if the platform needs them to perform inference.
@@ -171,7 +161,7 @@ You can pull the deployment image with Docker if it exists or :ref:`build it you
 
     .. code-tab:: console FPGA
 
-        # this image is not currently pre-built
+        # this image is not currently pre-built but you can build it yourself
 
 Start the image
 ---------------
@@ -202,6 +192,6 @@ By default, the container will start the server executable in the container that
 The ``--publish`` flags will map ports 8998 and 50051 in the container to arbitrary free ports on the host machine for HTTP and gRPC requests, respectively.
 You can use ``docker ps`` to show the running containers and what ports on the host machine are used by the container.
 Your clients will need these port numbers to make requests to the server.
-The endpoints for each model will be the name of the model in the ``config.pbtxt``, which should match the name of the parent directory in the model repository.
+The endpoints for each model will be the name of the model in the ``config.toml``, which should match the name of the parent directory in the model repository.
 In this example, it would be "resnet50".
 Once the container is started, you and any clients can :ref:`make requests to it <quickstart_inference:Quickstart - Inference>`.

--- a/examples/resnet50/quickstart-setup.sh
+++ b/examples/resnet50/quickstart-setup.sh
@@ -22,23 +22,20 @@ wget -O tensorflow.zip https://www.xilinx.com/bin/public/openDownload?filename=t
 unzip -j "tensorflow.zip" "tf_resnetv1_50_imagenet_224_224_6.97G_2.5/float/resnet_v1_50_baseline_6.96B_922.pb" -d .
 mkdir -p model_repository/resnet50/1
 mv ./resnet_v1_50_baseline_6.96B_922.pb model_repository/resnet50/1/saved_model.pb
-echo 'name: "resnet50"
-platform: "tensorflow_graphdef"
-inputs [
-    {
-        name: "input"
-        datatype: "FP32"
-        shape: [224,224,3]
-    }
-]
-outputs [
-    {
-        name: "resnet_v1_50/predictions/Reshape_1"
-        datatype: "FP32"
-        shape: [1000]
-    }
-]' > model_repository/resnet50/config.pbtxt
+cat << EOF > model_repository/resnet50/config.toml
+name = "mnist"
+platform = "tensorflow_graphdef"
 
+[[inputs]]
+name = "images_in"
+datatype = "FP32"
+shape = [28, 28, 1]
+
+[[outputs]]
+name = "flatten/Reshape"
+datatype = "FP32"
+shape = [10]
+EOF
 
 # Download the class labels for this model
 wget https://github.com/Xilinx/inference-server/raw/main/examples/resnet50/imagenet_classes.txt

--- a/src/amdinfer/clients/grpc_internal.cpp
+++ b/src/amdinfer/clients/grpc_internal.cpp
@@ -182,7 +182,7 @@ struct SetOutputData {
     data.resize(bytes_to_copy);
     const auto* contents = getTensorContents<T>(tensor);
     if constexpr (std::is_same_v<T, char>) {
-      std::memcpy(data.data(), contents, size * sizeof(std::byte));
+      std::memcpy(data.data(), (*contents)->data(), size * sizeof(T));
       output->setData(std::move(data));
     } else {
       if constexpr (util::is_any_v<T, int8_t, uint8_t, int16_t, uint16_t,

--- a/src/amdinfer/core/CMakeLists.txt
+++ b/src/amdinfer/core/CMakeLists.txt
@@ -40,7 +40,9 @@ amdinfer_add_protobuf_target(lib_config model_config.proto OFF)
 target_include_directories(
   model_repository PRIVATE $<TARGET_PROPERTY:lib_config,INCLUDE_DIRECTORIES>
 )
-target_link_libraries(model_repository INTERFACE efsw lib_config)
+target_link_libraries(
+  model_repository PRIVATE tomlplusplus::tomlplusplus INTERFACE efsw lib_config
+)
 add_dependencies(model_repository lib_config)
 
 target_include_directories(

--- a/src/amdinfer/core/CMakeLists.txt
+++ b/src/amdinfer/core/CMakeLists.txt
@@ -19,6 +19,7 @@ set(base_targets
     inference_request
     inference_response
     inference_tensor
+    model_config
     tensor
     model_metadata
     endpoints
@@ -41,6 +42,13 @@ target_include_directories(
 )
 target_link_libraries(model_repository INTERFACE efsw lib_config)
 add_dependencies(model_repository lib_config)
+
+target_include_directories(
+  model_config PRIVATE $<TARGET_PROPERTY:lib_config,INCLUDE_DIRECTORIES>
+)
+target_link_libraries(
+  model_config PRIVATE tomlplusplus::tomlplusplus INTERFACE lib_config
+)
 
 target_link_libraries(inference_tensor INTERFACE $<TARGET_OBJECTS:tensor>)
 target_link_libraries(

--- a/src/amdinfer/core/model_config.cpp
+++ b/src/amdinfer/core/model_config.cpp
@@ -1,0 +1,154 @@
+// Copyright 2023 Advanced Micro Devices, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file
+ * @brief
+ */
+
+#include "amdinfer/core/model_config.hpp"
+
+#include <toml++/toml.h>
+
+#include <filesystem>
+
+#include "amdinfer/core/exceptions.hpp"
+#include "model_config.pb.h"  // for Config, InferP...
+
+namespace fs = std::filesystem;
+
+namespace amdinfer {
+
+std::string extractString(const toml::table& table, const std::string& key,
+                          bool is_required) {
+  if (!table.contains(key)) {
+    if (is_required) {
+      throw invalid_argument("The configuration must have a " + key);
+    } else {
+      return "";
+    }
+  }
+
+  const auto& node = table.at(key);
+  if (!node.is_string()) {
+    throw invalid_argument(key + " must be a string");
+  }
+
+  return node.value<std::string>().value();
+}
+
+Tensor extractTensor(const toml::table& table);
+
+// if we're not explicitly handling the types, use this to catch the failure at
+// compile time
+template <class...>
+constexpr std::false_type templated_false{};
+
+template <typename T>
+std::vector<T> extractArray(const toml::table& table, const std::string& key) {
+  if (!table.contains(key)) {
+    throw invalid_argument("The configuration must have a " + key);
+  }
+
+  const auto& node = table.at(key);
+  if (!node.is_array()) {
+    throw invalid_argument(key + " must be an array");
+  }
+  if (!node.is_homogeneous()) {
+    throw invalid_argument(key + " must be a homogenous array");
+  }
+  const auto& array = *node.as_array();
+
+  std::vector<T> vector;
+  for (auto&& element : array) {
+    if constexpr (std::is_integral_v<T>) {
+      const auto optional_value = element.value<T>();
+      if (optional_value) {
+        vector.push_back(optional_value.value());
+      } else {
+        throw invalid_argument(
+          "One or more values could not be converted to integer in " + key);
+      }
+    } else if constexpr (std::is_same_v<T, Tensor>) {
+      if (!element.is_table()) {
+        throw invalid_argument(
+          "One or more values could not be converted to a table");
+      }
+      const auto& tbl = *element.as_table();
+      vector.push_back(extractTensor(tbl));
+    } else {
+      static_assert(templated_false<T>);
+    }
+  }
+
+  return vector;
+}
+
+Tensor extractTensor(const toml::table& table) {
+  auto name = extractString(table, "name", true);
+  auto datatype_str = extractString(table, "datatype", true);
+  auto shape = extractArray<uint64_t>(table, "shape");
+
+  DataType datatype{datatype_str.c_str()};
+
+  return {name, shape, datatype};
+}
+
+ModelConfig::ModelConfig(const toml::table& toml) {
+  if (toml.empty()) {
+    throw invalid_argument("The configuration cannot be empty");
+  }
+
+  name_ = extractString(toml, "name", true);
+  platform_ = extractString(toml, "platform", true);
+
+  inputs_ = extractArray<Tensor>(toml, "inputs");
+  outputs_ = extractArray<Tensor>(toml, "outputs");
+}
+
+ModelConfig::ModelConfig(const inference::Config& config)
+  : name_(config.name()), platform_(config.platform()) {
+  const auto& proto_inputs = config.inputs();
+  for (const auto& input : proto_inputs) {
+    const auto& name = input.name();
+    const DataType datatype{input.datatype().c_str()};
+    const auto& proto_shape = input.shape();
+    std::vector<uint64_t> shape;
+    shape.reserve(proto_shape.size());
+    for (const auto& index : proto_shape) {
+      shape.push_back(index);
+    }
+    inputs_.emplace_back(name, shape, datatype);
+  }
+
+  const auto& proto_outputs = config.outputs();
+  for (const auto& output : proto_outputs) {
+    const auto& name = output.name();
+    const DataType datatype{output.datatype().c_str()};
+    const auto& proto_shape = output.shape();
+    std::vector<uint64_t> shape;
+    shape.reserve(proto_shape.size());
+    for (const auto& index : proto_shape) {
+      shape.push_back(index);
+    }
+    outputs_.emplace_back(name, shape, datatype);
+  }
+}
+
+const std::string& ModelConfig::name() const { return name_; }
+const std::string& ModelConfig::platform() const { return platform_; }
+const std::vector<Tensor>& ModelConfig::inputs() const { return inputs_; }
+const std::vector<Tensor>& ModelConfig::outputs() const { return outputs_; }
+
+}  // namespace amdinfer

--- a/src/amdinfer/core/model_config.cpp
+++ b/src/amdinfer/core/model_config.cpp
@@ -184,6 +184,8 @@ ModelConfig::ModelConfig(const inference::Config& config) {
   configs_.emplace_back(model_name, platform, id, inputs, outputs);
 }
 
+size_t ModelConfig::size() const { return configs_.size(); }
+
 const std::string& ModelConfig::name(size_t index) const {
   return configs_.at(index).name;
 }

--- a/src/amdinfer/core/model_config.hpp
+++ b/src/amdinfer/core/model_config.hpp
@@ -70,6 +70,8 @@ class ModelConfig {
   explicit ModelConfig(const toml::v3::table& config);
   explicit ModelConfig(const inference::Config& config);
 
+  size_t size() const;
+
   const std::string& name(size_t index = 0) const;
   const std::string& platform(size_t index = 0) const;
   const std::string& id(size_t index = 0) const;

--- a/src/amdinfer/core/model_config.hpp
+++ b/src/amdinfer/core/model_config.hpp
@@ -20,9 +20,13 @@
 #ifndef GUARD_AMDINFER_CORE_MODEL_CONFIG
 #define GUARD_AMDINFER_CORE_MODEL_CONFIG
 
-#include <amdinfer/core/tensor.hpp>
+#include <filesystem>
 #include <string>
+#include <unordered_map>
 #include <vector>
+
+#include "amdinfer/core/parameters.hpp"
+#include "amdinfer/core/tensor.hpp"
 
 namespace toml {
 inline namespace v3 {
@@ -66,20 +70,52 @@ struct ModelConfigData {
 };
 
 class ModelConfig {
+  using Container = std::vector<std::pair<std::string, ParameterMap>>;
+  using Iterator = Container::iterator;
+  using ConstIterator = Container::const_iterator;
+  using ReverseIterator = Container::reverse_iterator;
+  using ConstReverseIterator = Container::const_reverse_iterator;
+
  public:
   explicit ModelConfig(const toml::v3::table& config);
   explicit ModelConfig(const inference::Config& config);
 
+  std::pair<std::string, ParameterMap> get(size_t index);
+  void setModelFiles(const std::filesystem::path& base_path);
+
   size_t size() const;
 
-  const std::string& name(size_t index = 0) const;
-  const std::string& platform(size_t index = 0) const;
-  const std::string& id(size_t index = 0) const;
-  const std::vector<ModelConfigTensor>& inputs(size_t index = 0) const;
-  const std::vector<ModelConfigTensor>& outputs(size_t index = 0) const;
+  /// Returns a read/write iterator to the first parameter in the object
+  Iterator begin();
+  /// Returns a read iterator to the first parameter in the object
+  [[nodiscard]] ConstIterator begin() const;
+  /// Returns a read iterator to the first parameter in the object
+  [[nodiscard]] ConstIterator cbegin() const;
+  /// Returns a read/write iterator to the first parameter in the object
+  ReverseIterator rbegin();
+  /// Returns a read iterator to the first parameter in the object
+  [[nodiscard]] ConstReverseIterator rbegin() const;
+  /// Returns a read iterator to the first parameter in the object
+  [[nodiscard]] ConstReverseIterator crbegin() const;
+
+  /// Returns a read/write iterator to one past the last parameter in the object
+  Iterator end();
+  /// Returns a read iterator to one past the last parameter in the object
+  [[nodiscard]] ConstIterator end() const;
+  /// Returns a read iterator to one past the last parameter in the object
+  [[nodiscard]] ConstIterator cend() const;
+  /// Returns a read/write iterator to the first parameter in the object
+  ReverseIterator rend();
+  /// Returns a read iterator to the first parameter in the object
+  [[nodiscard]] ConstReverseIterator rend() const;
+  /// Returns a read iterator to the first parameter in the object
+  [[nodiscard]] ConstReverseIterator crend() const;
 
  private:
   std::vector<ModelConfigData> configs_;
+  Container models_;
+
+  void createModels();
 };
 
 }  // namespace amdinfer

--- a/src/amdinfer/core/model_config.hpp
+++ b/src/amdinfer/core/model_config.hpp
@@ -36,21 +36,48 @@ class Config;
 
 namespace amdinfer {
 
+class ModelConfigTensor : public Tensor {
+ public:
+  ModelConfigTensor(std::string name, std::vector<uint64_t> shape,
+                    DataType data_type, std::string id);
+
+  const std::string& id() const&;
+  std::string id() &&;
+
+ private:
+  std::string id_;
+};
+
+struct ModelConfigData {
+  ModelConfigData(std::string name, std::string platform, std::string id,
+                  std::vector<ModelConfigTensor> inputs,
+                  std::vector<ModelConfigTensor> outputs)
+    : name(std::move(name)),
+      platform(std::move(platform)),
+      id(std::move(id)),
+      inputs(std::move(inputs)),
+      outputs(std::move(outputs)) {}
+
+  std::string name;
+  std::string platform;
+  std::string id;
+  std::vector<ModelConfigTensor> inputs;
+  std::vector<ModelConfigTensor> outputs;
+};
+
 class ModelConfig {
  public:
   explicit ModelConfig(const toml::v3::table& config);
   explicit ModelConfig(const inference::Config& config);
 
-  const std::string& name() const;
-  const std::string& platform() const;
-  const std::vector<Tensor>& inputs() const;
-  const std::vector<Tensor>& outputs() const;
+  const std::string& name(size_t index = 0) const;
+  const std::string& platform(size_t index = 0) const;
+  const std::string& id(size_t index = 0) const;
+  const std::vector<ModelConfigTensor>& inputs(size_t index = 0) const;
+  const std::vector<ModelConfigTensor>& outputs(size_t index = 0) const;
 
  private:
-  std::string name_;
-  std::string platform_;
-  std::vector<Tensor> inputs_;
-  std::vector<Tensor> outputs_;
+  std::vector<ModelConfigData> configs_;
 };
 
 }  // namespace amdinfer

--- a/src/amdinfer/core/model_config.hpp
+++ b/src/amdinfer/core/model_config.hpp
@@ -1,0 +1,58 @@
+// Copyright 2023 Advanced Micro Devices, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file
+ * @brief
+ */
+
+#ifndef GUARD_AMDINFER_CORE_MODEL_CONFIG
+#define GUARD_AMDINFER_CORE_MODEL_CONFIG
+
+#include <amdinfer/core/tensor.hpp>
+#include <string>
+#include <vector>
+
+namespace toml {
+inline namespace v3 {
+class table;
+}  // namespace v3
+}  // namespace toml
+
+namespace inference {
+class Config;
+}  // namespace inference
+
+namespace amdinfer {
+
+class ModelConfig {
+ public:
+  explicit ModelConfig(const toml::v3::table& config);
+  explicit ModelConfig(const inference::Config& config);
+
+  const std::string& name() const;
+  const std::string& platform() const;
+  const std::vector<Tensor>& inputs() const;
+  const std::vector<Tensor>& outputs() const;
+
+ private:
+  std::string name_;
+  std::string platform_;
+  std::vector<Tensor> inputs_;
+  std::vector<Tensor> outputs_;
+};
+
+}  // namespace amdinfer
+
+#endif  // GUARD_AMDINFER_CORE_MODEL_CONFIG

--- a/src/amdinfer/core/model_repository.cpp
+++ b/src/amdinfer/core/model_repository.cpp
@@ -31,6 +31,7 @@
 #include "amdinfer/core/parameters.hpp"      // for ParameterMap
 #include "amdinfer/observation/logging.hpp"  // for AMDINFER_LOG_D...
 #include "amdinfer/util/filesystem.hpp"      // for findFile
+#include "amdinfer/util/string.hpp"          // for endsWith
 #include "model_config.hpp"                  // for ModelConfig
 #include "model_config.pb.h"                 // for Config, InferP...
 
@@ -176,7 +177,7 @@ void UpdateListener::handleFileAction(
   AMDINFER_IF_LOGGING(Logger logger{Loggers::Server};)
   // arbitrary delay to make sure filesystem has settled
   const std::chrono::milliseconds delay{100};
-  if (filename == "proto_config.pbtxt") {
+  if (filename == "config.pbtxt" || util::endsWith(filename, "toml")) {
     if (action == efsw::Actions::Add) {
       std::this_thread::sleep_for(delay);
       auto model_name = fs::path(dir).parent_path().filename();

--- a/src/amdinfer/core/model_repository.hpp
+++ b/src/amdinfer/core/model_repository.hpp
@@ -25,6 +25,7 @@ namespace amdinfer {
 
 class Endpoints;
 class ParameterMap;
+class ModelConfig;
 
 class UpdateListener : public efsw::FileWatchListener {
  public:
@@ -39,8 +40,8 @@ class UpdateListener : public efsw::FileWatchListener {
   Endpoints* endpoints_;
 };
 
-void parseModel(const std::filesystem::path& repository,
-                const std::string& model, ParameterMap* parameters);
+ModelConfig parseModel(const std::filesystem::path& repository,
+                       const std::string& model);
 
 class ModelRepository {
  public:

--- a/src/amdinfer/core/parameters.cpp
+++ b/src/amdinfer/core/parameters.cpp
@@ -44,11 +44,14 @@ ParameterMap::ParameterMap(const std::vector<std::string> &keys,
 }
 
 void ParameterMap::put(const std::string &key, Parameter value) {
-  this->parameters_.try_emplace(key, std::move(value));
+  auto [iter, emplaced] = this->parameters_.try_emplace(key, std::move(value));
+  if (!emplaced) {
+    iter->second = value;
+  }
 }
 
 void ParameterMap::put(const std::string &key, const char *value) {
-  this->parameters_.try_emplace(key, std::string{value});
+  put(key, std::string{value});
 }
 
 void ParameterMap::erase(const std::string &key) {

--- a/src/amdinfer/models/CMakeLists.txt
+++ b/src/amdinfer/models/CMakeLists.txt
@@ -18,7 +18,7 @@ set(filenames base64_encode base64_decode echo echo_multi invert_image)
 set(targets "")
 
 function(amdinfer_get_target_name target filename)
-  set(${target} ${filename}_model PARENT_SCOPE)
+  set(${target} ${filename} PARENT_SCOPE)
 endfunction()
 
 foreach(filename ${filenames})

--- a/src/amdinfer/models/base64_decode.cpp
+++ b/src/amdinfer/models/base64_decode.cpp
@@ -80,7 +80,7 @@ amdinfer::BatchPtr run(amdinfer::Batch* batch) {
 
     auto new_request = req->propagate();
 
-    auto* input_data = static_cast<char*>(input.getData());
+    const auto* input_data = static_cast<char*>(input.getData());
     auto decoded_str = amdinfer::util::base64Decode(input_data, input_size);
     std::vector<char> data(decoded_str.begin(), decoded_str.end());
     cv::Mat img;

--- a/src/amdinfer/servers/grpc_server.cpp
+++ b/src/amdinfer/servers/grpc_server.cpp
@@ -206,8 +206,13 @@ struct WriteData {
   void operator()(Buffer* buffer, Tensor* tensor, size_t offset, size_t size,
                   [[maybe_unused]] const Observer& observer) const {
     auto* contents = getTensorContents<T>(tensor);
-    if constexpr (util::is_any_v<T, bool, uint32_t, uint64_t, int32_t, int64_t,
-                                 float, double, char>) {
+    if constexpr (std::is_same_v<T, char>) {
+      // gRPC stores char as a string so contents is a string**. Copy over the
+      // actual char* data from the string
+      auto* dest = static_cast<std::byte*>(buffer->data(offset));
+      std::memcpy(dest, (*contents)->data(), size * sizeof(T));
+    } else if constexpr (util::is_any_v<T, bool, uint32_t, uint64_t, int32_t,
+                                        int64_t, float, double>) {
       auto* dest = static_cast<std::byte*>(buffer->data(offset));
       std::memcpy(dest, contents, size * sizeof(T));
     } else if constexpr (util::is_any_v<T, uint8_t, uint16_t, int8_t, int16_t,

--- a/src/amdinfer/servers/http_server.cpp
+++ b/src/amdinfer/servers/http_server.cpp
@@ -505,10 +505,11 @@ void HttpServer::modelInfer(
   } catch (const invalid_argument &e) {
     AMDINFER_LOG_INFO(logger_, e.what());
     auto resp = errorHttpResponse(e.what(), HttpStatusCode::k400BadRequest);
-#ifdef AMDINFER_ENABLE_TRACING
-    auto context = trace->propagate();
-    propagate(resp.get(), context);
-#endif
+    // TODO(varunsh): could use after move here from the try block
+    // #ifdef AMDINFER_ENABLE_TRACING
+    //     auto context = trace->propagate();
+    //     propagate(resp.get(), context);
+    // #endif
     callback(resp);
   }
 }

--- a/src/amdinfer/util/CMakeLists.txt
+++ b/src/amdinfer/util/CMakeLists.txt
@@ -17,8 +17,9 @@ set(base_targets
     base64
     compression
     ctpl
-    parse_env
     exec
+    filesystem
+    parse_env
     read_nth_line
     timer
 )

--- a/src/amdinfer/util/filesystem.cpp
+++ b/src/amdinfer/util/filesystem.cpp
@@ -1,0 +1,41 @@
+// Copyright 2023 Advanced Micro Devices, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "amdinfer/util/filesystem.hpp"
+
+#include "amdinfer/core/exceptions.hpp"
+
+namespace fs = std::filesystem;
+
+namespace amdinfer::util {
+
+fs::path findFile(const fs::path& directory, const std::string& extension) {
+  fs::path found_path;
+  for (const auto& entry : fs::directory_iterator(directory)) {
+    if (entry.is_directory()) {
+      continue;
+    }
+    const auto& path = entry.path();
+    if (path.extension().string() != extension) {
+      continue;
+    }
+
+    return path;
+  }
+
+  throw file_not_found_error("No file found in " + directory.string() +
+                             " with the extension " + extension);
+}
+
+}  // namespace amdinfer::util

--- a/src/amdinfer/util/filesystem.hpp
+++ b/src/amdinfer/util/filesystem.hpp
@@ -22,7 +22,8 @@ namespace amdinfer::util {
 /**
  * @brief Get the path to the file in a directory with the given extension. If
  * there is more than one file in the directory that matches, only the first one
- * found is returned. Subdirectories are not searched.
+ * found is returned. If extension is empty, then the first found file is
+ * returned. Subdirectories are not searched.
  *
  * @param directory path to search in
  * @param extension extension of the file to search for
@@ -30,6 +31,8 @@ namespace amdinfer::util {
  */
 std::filesystem::path findFile(const std::filesystem::path& directory,
                                const std::string& extension);
+
+std::string readFile(const std::string& path);
 
 }  // namespace amdinfer::util
 

--- a/src/amdinfer/util/filesystem.hpp
+++ b/src/amdinfer/util/filesystem.hpp
@@ -1,0 +1,36 @@
+// Copyright 2023 Advanced Micro Devices, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GUARD_AMDINFER_UTIL_FILESYSTEM
+#define GUARD_AMDINFER_UTIL_FILESYSTEM
+
+#include <filesystem>
+
+namespace amdinfer::util {
+
+/**
+ * @brief Get the path to the file in a directory with the given extension. If
+ * there is more than one file in the directory that matches, only the first one
+ * found is returned. Subdirectories are not searched.
+ *
+ * @param directory path to search in
+ * @param extension extension of the file to search for
+ * @return std::filesystem::path
+ */
+std::filesystem::path findFile(const std::filesystem::path& directory,
+                               const std::string& extension);
+
+}  // namespace amdinfer::util
+
+#endif  // GUARD_AMDINFER_UTIL_FILESYSTEM

--- a/src/amdinfer/workers/c_plus_plus.cpp
+++ b/src/amdinfer/workers/c_plus_plus.cpp
@@ -43,6 +43,7 @@
 #include "amdinfer/observation/tracing.hpp"  // for startFollowSpan, SpanPtr
 #include "amdinfer/util/containers.hpp"      // for containerSum
 #include "amdinfer/util/queue.hpp"           // for BufferPtrsQueue
+#include "amdinfer/util/string.hpp"          // for endsWith
 #include "amdinfer/util/thread.hpp"          // for setThreadName
 #include "amdinfer/util/timer.hpp"           // for Timer
 #include "amdinfer/workers/worker.hpp"       // for Worker
@@ -149,7 +150,11 @@ void CPlusPlus::doInit(ParameterMap* parameters) {
     throw invalid_argument("No model specified");
   }
 
-  handle_ = openModel("lib" + model + "_model.so");
+  if (!util::endsWith(model, ".so")) {
+    model = "lib" + model + ".so";
+  }
+
+  handle_ = openModel(model);
 }
 
 void CPlusPlus::doAcquire([[maybe_unused]] ParameterMap* parameters) {

--- a/tests/unit/core/CMakeLists.txt
+++ b/tests/unit/core/CMakeLists.txt
@@ -23,7 +23,7 @@ list(
 )
 
 list(APPEND tests_libs "inference_request~parameters~inference_response"
-            "model_config~tensor~data_types" "parameters"
+            "model_config~tensor~data_types~parameters~util" "parameters"
 )
 
 amdinfer_add_unit_tests("${tests}" "${tests_libs}")

--- a/tests/unit/core/test_model_config.cpp
+++ b/tests/unit/core/test_model_config.cpp
@@ -140,8 +140,8 @@ TEST(UnitModelConfig, Chain) {
   ModelConfig config{toml};
 
   ASSERT_EQ(config.size(), 3);
-  std::array<std::string, 3> models{"preprocess", "invert_image",
-                                    "postprocess"};
+  std::array<std::string, 3> models{"invert_image", "execute",
+                                    "invert_image_postprocess"};
 
   auto index = 0;
   for (const auto& [model, parameters] : config) {

--- a/tests/unit/core/test_model_config.cpp
+++ b/tests/unit/core/test_model_config.cpp
@@ -85,14 +85,14 @@ TEST(UnitModelConfig, SingleEnsemble) {
 TEST(UnitModelConfig, Chain) {
   constexpr std::string_view toml_str = R"(
     [[models]]
-    name = "preprocess"
+    name = "invert_image"
     platform = "amdinfer_cpp"
     id = "base64_decode.so"
 
     [[models.inputs]]
     name = "image_in"
-    datatype = "INT8"
-    shape = [1080, 1920, 3]
+    datatype = "STRING"
+    shape = [1048576]
     id = ""
 
     [[models.outputs]]
@@ -102,7 +102,7 @@ TEST(UnitModelConfig, Chain) {
     id = "preprocessed_image"
 
     [[models]]
-    name = "invert_image"
+    name = "execute"
     platform = "amdinfer_cpp"
     id = "invert_image.so"
 
@@ -119,7 +119,7 @@ TEST(UnitModelConfig, Chain) {
     id = "inverted_image"
 
     [[models]]
-    name = "postprocess"
+    name = "invert_image_postprocess"
     platform = "amdinfer_cpp"
     id = "base64_encode.so"
 
@@ -131,8 +131,8 @@ TEST(UnitModelConfig, Chain) {
 
     [[models.outputs]]
     name = "image_out"
-    datatype = "INT8"
-    shape = [1080, 1920, 3]
+    datatype = "STRING"
+    shape = [1048576]
     id = "postprocessed_image"
   )"sv;
 

--- a/tests/unit/core/test_model_config.cpp
+++ b/tests/unit/core/test_model_config.cpp
@@ -1,0 +1,70 @@
+// Copyright 2023 Advanced Micro Devices, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <toml++/toml.h>
+
+#include <iostream>
+
+#include "amdinfer/core/model_config.hpp"  // for ModelConfig
+#include "gtest/gtest.h"                   // for Message, TestPartResult, Test
+
+using namespace std::string_view_literals;
+
+namespace amdinfer {
+
+static constexpr std::string_view toml_str = R"(
+  name = "mnist"
+  platform = "tensorflow_graphdef"
+
+  [[inputs]]
+  name = "images_in"
+  datatype = "FP32"
+  shape = [28, 28, 1]
+
+  [[outputs]]
+  name = "flatten/Reshape"
+  datatype = "FP32"
+  shape = [10]
+)"sv;
+
+// NOLINTNEXTLINE(cert-err58-cpp, cppcoreguidelines-owning-memory)
+TEST(UnitModelConfig, Construction) {
+  const auto toml = toml::parse(toml_str);
+  ModelConfig config{toml};
+
+  EXPECT_EQ(config.name(), "mnist");
+  EXPECT_EQ(config.platform(), "tensorflow_graphdef");
+
+  const auto& inputs = config.inputs();
+  EXPECT_EQ(inputs.size(), 1);
+  const auto& input = inputs.at(0);
+  EXPECT_EQ(input.getName(), "images_in");
+  EXPECT_EQ(input.getDatatype(), DataType::Fp32);
+  const auto& input_shape = input.getShape();
+  EXPECT_EQ(input_shape.size(), 3);
+  const std::vector<uint64_t> golden_input_shape{28, 28, 1};
+  EXPECT_EQ(input_shape, golden_input_shape);
+
+  const auto& outputs = config.outputs();
+  EXPECT_EQ(outputs.size(), 1);
+  const auto& output = outputs.at(0);
+  EXPECT_EQ(output.getName(), "flatten/Reshape");
+  EXPECT_EQ(output.getDatatype(), DataType::Fp32);
+  const auto& output_shape = output.getShape();
+  EXPECT_EQ(output_shape.size(), 1);
+  const std::vector<uint64_t> golden_output_shape{10};
+  EXPECT_EQ(output_shape, golden_output_shape);
+}
+
+}  // namespace amdinfer

--- a/tests/unit/core/test_model_config.cpp
+++ b/tests/unit/core/test_model_config.cpp
@@ -23,12 +23,13 @@ using namespace std::string_view_literals;
 
 namespace amdinfer {
 
-void validateMetadata(const ModelConfig& config, const std::string& golden_name,
+void validateMetadata(const ModelConfig& config, size_t index,
+                      const std::string& golden_name,
                       const std::string& golden_platform,
                       const std::string& golden_id) {
-  EXPECT_EQ(config.name(), golden_name);
-  EXPECT_EQ(config.platform(), golden_platform);
-  EXPECT_EQ(config.id(), golden_id);
+  EXPECT_EQ(config.name(index), golden_name);
+  EXPECT_EQ(config.platform(index), golden_platform);
+  EXPECT_EQ(config.id(index), golden_id);
 }
 
 void validateTensor(const ModelConfigTensor& tensor,
@@ -61,7 +62,7 @@ TEST(UnitModelConfig, Basic) {
   ModelConfig config{toml};
 
   ASSERT_NO_FATAL_FAILURE(
-    validateMetadata(config, "mnist", "tensorflow_graphdef", ""));
+    validateMetadata(config, 0, "mnist", "tensorflow_graphdef", ""));
 
   const auto& inputs = config.inputs();
   EXPECT_EQ(inputs.size(), 1);
@@ -103,7 +104,7 @@ TEST(UnitModelConfig, SingleEnsemble) {
   ModelConfig config{toml};
 
   ASSERT_NO_FATAL_FAILURE(
-    validateMetadata(config, "mnist", "tensorflow_graphdef", "bar.pb"));
+    validateMetadata(config, 0, "mnist", "tensorflow_graphdef", "bar.pb"));
 
   const auto& inputs = config.inputs();
   EXPECT_EQ(inputs.size(), 1);
@@ -118,6 +119,97 @@ TEST(UnitModelConfig, SingleEnsemble) {
 
   Tensor golden_output{"flatten/Reshape", {10}, DataType::Fp32};
   ASSERT_NO_FATAL_FAILURE(validateTensor(output, golden_output, "classes"));
+}
+
+// NOLINTNEXTLINE(cert-err58-cpp, cppcoreguidelines-owning-memory)
+TEST(UnitModelConfig, Chain) {
+  constexpr std::string_view toml_str = R"(
+    [[models]]
+    name = "preprocess"
+    platform = "amdinfer_cpp"
+    id = "base64_decode.so"
+
+    [[models.inputs]]
+    name = "image_in"
+    datatype = "INT8"
+    shape = [1080, 1920, 3]
+    id = ""
+
+    [[models.outputs]]
+    name = "image_out"
+    datatype = "INT8"
+    shape = [1080, 1920, 3]
+    id = "preprocessed_image"
+
+    [[models]]
+    name = "invert_image"
+    platform = "amdinfer_cpp"
+    id = "invert_image.so"
+
+    [[models.inputs]]
+    name = "image_in"
+    datatype = "INT8"
+    shape = [1080, 1920, 3]
+    id = "preprocessed_image"
+
+    [[models.outputs]]
+    name = "image_out"
+    datatype = "INT8"
+    shape = [1080, 1920, 3]
+    id = "inverted_image"
+
+    [[models]]
+    name = "postprocess"
+    platform = "amdinfer_cpp"
+    id = "base64_encode.so"
+
+    [[models.inputs]]
+    name = "image_in"
+    datatype = "INT8"
+    shape = [1080, 1920, 3]
+    id = "inverted_image"
+
+    [[models.outputs]]
+    name = "image_out"
+    datatype = "INT8"
+    shape = [1080, 1920, 3]
+    id = "postprocessed_image"
+  )"sv;
+
+  const auto toml = toml::parse(toml_str);
+  std::cout << toml::json_formatter{toml} << std::endl;
+  ModelConfig config{toml};
+
+  ASSERT_NO_FATAL_FAILURE(validateMetadata(config, 0, "preprocess",
+                                           "amdinfer_cpp", "base64_decode.so"));
+  ASSERT_NO_FATAL_FAILURE(validateMetadata(config, 1, "invert_image",
+                                           "amdinfer_cpp", "invert_image.so"));
+  ASSERT_NO_FATAL_FAILURE(validateMetadata(config, 2, "postprocess",
+                                           "amdinfer_cpp", "base64_encode.so"));
+
+  const auto count = 3;
+
+  ASSERT_EQ(config.size(), count);
+
+  std::array<std::string, count> golden_input_ids{"", "preprocessed_image",
+                                                  "inverted_image"};
+  std::array<std::string, count> golden_output_ids{
+    "preprocessed_image", "inverted_image", "postprocessed_image"};
+
+  for (auto i = 0; i < count; ++i) {
+    const auto& inputs = config.inputs(i);
+    ASSERT_EQ(inputs.size(), 1);
+    const auto& outputs = config.outputs(i);
+    ASSERT_EQ(outputs.size(), 1);
+    const auto& input = inputs.at(0);
+    const auto& output = outputs.at(0);
+    Tensor golden_input{"image_in", {1080, 1920, 3}, DataType::Int8};
+    ASSERT_NO_FATAL_FAILURE(
+      validateTensor(input, golden_input, golden_input_ids.at(i)));
+    Tensor golden_output{"image_out", {1080, 1920, 3}, DataType::Int8};
+    ASSERT_NO_FATAL_FAILURE(
+      validateTensor(output, golden_output, golden_output_ids.at(i)));
+  }
 }
 
 }  // namespace amdinfer


### PR DESCRIPTION
# Summary of Changes

* Enable defining ensembles in repositories for use with `modelLoad` or KServe

Closes #177 

# Motivation

#173 added model chaining through the C++ API. This PR adds the same functionality through the `modelLoad` API used in the deployment examples and with KServe.

# Implementation

I switched to using TOML as the primary format to define the model configuration to more easily support different definition formats. In a protobuf-based format, any new variant would need its own schema. With TOML, it can support a simplified one-model case as well as a more complex ensemble case directly.

A full ensemble definition in TOML looks like this:

```toml
[[models]]
name = "invert_image"
platform = "amdinfer_cpp"
id = "base64_decode.so"

[[models.inputs]]
name = "image_in"
datatype = "STRING"
shape = [1048576]
id = ""

[[models.outputs]]
name = "image_out"
datatype = "INT8"
shape = [1080, 1920, 3]
id = "preprocessed_image"

[[models]]
name = "execute"
platform = "amdinfer_cpp"
id = "invert_image.so"

[[models.inputs]]
name = "image_in"
datatype = "INT8"
shape = [1080, 1920, 3]
id = "preprocessed_image"

[[models.outputs]]
name = "image_out"
datatype = "INT8"
shape = [1080, 1920, 3]
id = "inverted_image"

[[models]]
name = "invert_image_postprocess"
platform = "amdinfer_cpp"
id = "base64_encode.so"

[[models.inputs]]
name = "image_in"
datatype = "INT8"
shape = [1080, 1920, 3]
id = "inverted_image"

[[models.outputs]]
name = "image_out"
datatype = "STRING"
shape = [1048576]
id = "postprocessed_image"
```

Multiple models can be specified using multiple `[[models]]` tags and similarly, multiple input/output tensors for each model can be added using the appropriate tags. Each output tensor should have a unique ID that gets mapped to one input tensor. In the future, this syntax will support true ensembles but since only linear chains are supported for now, the ID field is effectively unused: all the output tensors of one model are fed to the next. Another addition now is the ID field on the model. Since multiple model files will now exist in the same directory, the ID field for the model must identify which model file matches it. The name field is used to name the endpoints as before. For consistency, the name of the first model should match the name of the repository directory.

In the simple case, with a single model, you can drop the ID fields, drop the `[[models]]` tags and prefixes so it behaves as the old pbtxt format converted to TOML. The pbtxt format continues to be supported for backwards compatibility though it may be dropped in the future.

# Notes

I updated the documentation to use the simpler TOML format (non-ensemble). There are currently no ensemble examples nor a test case for ensembles.
