### PR TITLE
Pin python packages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,6 +150,7 @@ add_option("ENABLE_TFZENDNN" "Enable TF+ZenDNN worker" ${tfzendnn_FOUND})
 add_option("ENABLE_PTZENDNN" "Enable PT+ZenDNN worker" ${ptzendnn_FOUND})
 add_option("ENABLE_MIGRAPHX" "Enable migraphx worker" ${migraphx_FOUND})
 add_option("ENABLE_PYTHON_BINDINGS" "Build Python bindings" ON)
+add_option("INSTALL" "Set when invoking installation" OFF)
 
 # override tracing option and disable it if building Python bindings
 if(SKBUILD)

--- a/amdinfer
+++ b/amdinfer
@@ -761,7 +761,7 @@ class Install:
                     None, "No manifest found. Install amdinfer first."
                 )
 
-        build_args = f"--dir {args.dir} --release --regen -DAMDINFER_BUILD_TESTING=OFF "
+        build_args = f"--dir {args.dir} --release --regen -DAMDINFER_BUILD_TESTING=OFF -DAMDINFER_INSTALL=ON "
         if unknown_args:
             build_args += " ".join(unknown_args)
 

--- a/docker/generate.py
+++ b/docker/generate.py
@@ -682,6 +682,37 @@ def install_migraphx(manager: PackageManager, custom_backends):
 
 
 def install_python_packages():
+    # The versions are pinned to prevent package updates from breaking the
+    # container. To update this list, install the packages we actually want:
+    #     pip install --no-cache-dir --ignore-installed \
+    #         pytest \
+    #         pytest-cpp \
+    #         pytest-xprocess \
+    #         requests \
+    #         breathe \
+    #         fastcov \
+    #         sphinx \
+    #         sphinx_copybutton \
+    #         sphinxcontrib-confluencebuilder \
+    #         sphinx-argparse \
+    #         sphinxemoji \
+    #         sphinx-issues \
+    #         exhale \
+    #         sphinx-tabs \
+    #         sphinx-tippy \
+    #         sphinxcontrib-openapi \
+    #         sphinxcontrib-jquery \
+    #         black \
+    #         cpplint \
+    #         cmakelang  \
+    #         pre-commit \
+    #         opencv-python-headless \
+    #         scikit-build \
+    #         pytest-benchmark \
+    #         rich \
+    #         pybind11_mkdoc \
+    #         pybind11-stubgen
+
     return textwrap.dedent(
         """\
         RUN python3 -m pip install --upgrade --force-reinstall pip \\
@@ -691,39 +722,94 @@ def install_python_packages():
                 wheel \\
             # clang-tidy-10 installs pyyaml which can't be uninstalled with pip
             && pip install --no-cache-dir --ignore-installed \\
-                # install testing dependencies
-                pytest \\
-                pytest-cpp \\
-                pytest-xprocess \\
-                requests \\
-                # install documentation dependencies
-                breathe \\
-                fastcov \\
-                sphinx \\
-                sphinx_copybutton \\
-                sphinxcontrib-confluencebuilder \\
-                sphinx-argparse \\
-                sphinxemoji \\
-                sphinx-issues \\
-                exhale \\
-                sphinx-tabs \\
-                sphinx-tippy \\
-                sphinxcontrib-openapi \\
-                sphinxcontrib-jquery \\
-                # install linting tools
-                black \\
-                cpplint \\
-                cmakelang  \\
-                pre-commit \\
-                # install dependencies
-                opencv-python-headless \\
-                scikit-build \\
-                # install benchmarking dependencies
-                pytest-benchmark \\
-                rich \\
-                # used for Python bindings
-                pybind11_mkdoc \\
-                pybind11-stubgen
+                "alabaster==0.7.13" \\
+                "attrs==23.1.0" \\
+                "Babel==2.12.1" \\
+                "beautifulsoup4==4.12.2" \\
+                "black==23.3.0" \\
+                "breathe==4.35.0" \\
+                "certifi==2022.12.7" \\
+                "cfgv==3.3.1" \\
+                "charset-normalizer==3.1.0" \\
+                "clang==14.0" \\
+                "click==8.1.3" \\
+                "cmakelang==0.6.13" \\
+                "colorama==0.4.6" \\
+                "cpplint==1.6.1" \\
+                "deepmerge==1.1.0" \\
+                "distlib==0.3.6" \\
+                "distro==1.8.0" \\
+                "docutils==0.17.1" \\
+                "exceptiongroup==1.1.1" \\
+                "exhale==0.3.6" \\
+                "fastcov==1.14" \\
+                "filelock==3.12.0" \\
+                "identify==2.5.22" \\
+                "idna==3.4" \\
+                "imagesize==1.4.1" \\
+                "importlib-metadata==6.5.0" \\
+                "importlib-resources==5.12.0" \\
+                "iniconfig==2.0.0" \\
+                "Jinja2==3.0.3" \\
+                "jsonschema==4.17.3" \\
+                "lxml==4.9.2" \\
+                "markdown-it-py==2.2.0" \\
+                "MarkupSafe==2.1.2" \\
+                "mdurl==0.1.2" \\
+                "mistune==2.0.5" \\
+                "mypy-extensions==1.0.0" \\
+                "nodeenv==1.7.0" \\
+                "numpy==1.24.2" \\
+                "opencv-python-headless==4.7.0.72" \\
+                "packaging==23.1" \\
+                "pathspec==0.11.1" \\
+                "picobox==3.0.0" \\
+                "pkgutil_resolve_name==1.3.10" \\
+                "platformdirs==3.2.0" \\
+                "pluggy==1.0.0" \\
+                "pre-commit==3.2.2" \\
+                "psutil==5.9.5" \\
+                "py==1.11.0" \\
+                "py-cpuinfo==9.0.0" \\
+                "pybind11-stubgen==0.13.0" \\
+                "pybind11_mkdoc==2.6.2" \\
+                "Pygments==2.15.1" \\
+                "pyrsistent==0.19.3" \\
+                "pytest==7.3.1" \\
+                "pytest-benchmark==4.0.0" \\
+                "pytest-cpp==2.3.0" \\
+                "pytest-xprocess==0.22.2" \\
+                "pytz==2023.3" \\
+                "PyYAML==6.0" \\
+                "requests==2.28.2" \\
+                "rich==13.3.4" \\
+                "scikit-build==0.17.2" \\
+                "six==1.16.0" \\
+                "snowballstemmer==2.2.0" \\
+                "soupsieve==2.4.1" \\
+                "Sphinx==4.5.0" \\
+                "sphinx-argparse==0.4.0" \\
+                "sphinx-copybutton==0.5.2" \\
+                "sphinx-issues==3.0.1" \\
+                "sphinx-tabs==3.4.0" \\
+                "sphinx_mdinclude==0.5.3" \\
+                "sphinx_tippy==0.4.1" \\
+                "sphinxcontrib-applehelp==1.0.4" \\
+                "sphinxcontrib-confluencebuilder==2.0.0" \\
+                "sphinxcontrib-devhelp==1.0.2" \\
+                "sphinxcontrib-htmlhelp==2.0.1" \\
+                "sphinxcontrib-httpdomain==1.8.1" \\
+                "sphinxcontrib-jquery==4.1" \\
+                "sphinxcontrib-jsmath==1.0.1" \\
+                "sphinxcontrib-openapi==0.8.1" \\
+                "sphinxcontrib-qthelp==1.0.3" \\
+                "sphinxcontrib-serializinghtml==1.1.5" \\
+                "sphinxemoji==0.2.0" \\
+                "tomli==2.0.1" \\
+                "typing_extensions==4.5.0" \\
+                "urllib3==1.26.15" \\
+                "virtualenv==20.22.0" \\
+                "zipp==3.15.0"
         """
     )
 

--- a/docs/dependencies.rst
+++ b/docs/dependencies.rst
@@ -115,35 +115,35 @@ The following packages (and any dependencies) are installed from the Python Pack
     :header: Name,Version,License,Usage
     :widths: auto
 
-    :pypiPackages:`black`,latest,MIT,Formatting Python files\ :superscript:`d 0`
-    :pypiPackages:`breathe`,latest,BSD-3,Connect Doxygen to Sphinx for documentation\ :superscript:`d 0`
-    :pypiPackages:`cmakelang`,latest,GPL-3,CMake linter and formatter\ :superscript:`d 0`
-    :pypiPackages:`cpplint`,latest,BSD-3,C++ linter\ :superscript:`d 0`
-    :pypiPackages:`exhale`,latest,BSD-3,Documentation generator\ :superscript:`d 0`
-    :pypiPackages:`fastcov`,latest,MIT,Reporting test coverage\ :superscript:`d 0`
-    :pypiPackages:`numpy`,latest,BSD-3,Scientific computing package for Python\ :superscript:`d 0`
-    :pypiPackages:`opencv-python-headless`,latest,MIT,Python bindings for OpenCV\ :superscript:`d 0`
+    :pypiPackages:`black`,23.3.0,MIT,Formatting Python files\ :superscript:`d 0`
+    :pypiPackages:`breathe`,4.35.0,BSD-3,Connect Doxygen to Sphinx for documentation\ :superscript:`d 0`
+    :pypiPackages:`cmakelang`,0.6.13,GPL-3,CMake linter and formatter\ :superscript:`d 0`
+    :pypiPackages:`cpplint`,1.6.1,BSD-3,C++ linter\ :superscript:`d 0`
+    :pypiPackages:`exhale`,0.3.6,BSD-3,Documentation generator\ :superscript:`d 0`
+    :pypiPackages:`fastcov`,1.14,MIT,Reporting test coverage\ :superscript:`d 0`
+    :pypiPackages:`numpy`,1.24.2,BSD-3,Scientific computing package for Python\ :superscript:`d 0`
+    :pypiPackages:`opencv-python-headless`,4.7.0.72,MIT,Python bindings for OpenCV\ :superscript:`d 0`
     :pypiPackages:`pip`,latest,MIT,Python package installer\ :superscript:`d 0`
-    :pypiPackages:`pre-commit`,latest,MIT,Pre-commit hook framework\ :superscript:`d 0`
-    :pypiPackages:`pybind11_mkdoc`,latest,MIT,Used to extract function documentation for Python binding\ :superscript:`d 0`
-    :pypiPackages:`pybind11-stubgen`,latest,BSD-3,Used to generate type stubs for Python binding\ :superscript:`d 0`
-    :pypiPackages:`pytest`,latest,MIT,Python testing infrastructure\ :superscript:`d 0`
-    :pypiPackages:`pytest-benchmark`,latest,BSD-2,Plugin for Pytest to add benchmarking\ :superscript:`d 0`
-    :pypiPackages:`pytest-cpp`,latest,MIT,Plugin for Pytest to run C++ tests\ :superscript:`d 0`
-    :pypiPackages:`pytest-xprocess`,latest,MIT,Plugin for Pytest to run external processes\ :superscript:`d 0`
-    :pypiPackages:`requests`,latest,Apache-2.0,Making REST requests\ :superscript:`d 0`
-    :pypiPackages:`rich`,latest,MIT,Printing tables when benchmarking\ :superscript:`d 0`
+    :pypiPackages:`pre-commit`,3.2.2,MIT,Pre-commit hook framework\ :superscript:`d 0`
+    :pypiPackages:`pybind11_mkdoc`,2.6.2,MIT,Used to extract function documentation for Python binding\ :superscript:`d 0`
+    :pypiPackages:`pybind11-stubgen`,0.13.0,BSD-3,Used to generate type stubs for Python binding\ :superscript:`d 0`
+    :pypiPackages:`pytest`,7.3.1,MIT,Python testing infrastructure\ :superscript:`d 0`
+    :pypiPackages:`pytest-benchmark`,4.0.0,BSD-2,Plugin for Pytest to add benchmarking\ :superscript:`d 0`
+    :pypiPackages:`pytest-cpp`,2.3.0,MIT,Plugin for Pytest to run C++ tests\ :superscript:`d 0`
+    :pypiPackages:`pytest-xprocess`,0.22.2,MIT,Plugin for Pytest to run external processes\ :superscript:`d 0`
+    :pypiPackages:`requests`,2.28.2,Apache-2.0,Making REST requests\ :superscript:`d 0`
+    :pypiPackages:`rich`,13.3.4,MIT,Printing tables when benchmarking\ :superscript:`d 0`
     :pypiPackages:`setuptools`,latest,MIT,Manage Python packages\ :superscript:`d 0`
-    :pypiPackages:`Sphinx`,latest,BSD-2 + others,Building documentation\ :superscript:`d 0`
-    :pypiPackages:`sphinx-argparse`,latest,MIT,Sphinx plugin for documenting CLIs\ :superscript:`d 0`
-    :pypiPackages:`sphinx-copybutton`,latest,MIT,Adds copy button for code blocks\ :superscript:`d 0`
-    :pypiPackages:`sphinxemoji`,latest,BSD-3,Sphinx plugin for enabling emoji\ :superscript:`d 0`
-    :pypiPackages:`sphinx-issues`,latest,MIT,Sphinx plugin for links to the project's Github issue tracker\ :superscript:`d 0`
-    :pypiPackages:`sphinx-tabs`,latest,MIT,Sphinx plugin to create tabs\ :superscript:`d 0`
-    :pypiPackages:`sphinx_tippy`,latest,MIT,Sphinx plugin to create tooltips\ :superscript:`d 0`
-    :pypiPackages:`sphinxcontrib-confluencebuilder`,latest,BSD-2,Sphinx plugin to export documentation to Confluence\ :superscript:`d 0`
-    :pypiPackages:`sphinxcontrib-jquery`,latest,BSD-0,Sphinx plugin to add JQuery\ :superscript:`d 0`
-    :pypiPackages:`sphinxcontrib-openapi`,latest,BSD-2,Sphinx plugin to build OpenAPI docs\ :superscript:`d 0`
+    :pypiPackages:`Sphinx`,4.5.0,BSD-2 + others,Building documentation\ :superscript:`d 0`
+    :pypiPackages:`sphinx-argparse`,0.4.0,MIT,Sphinx plugin for documenting CLIs\ :superscript:`d 0`
+    :pypiPackages:`sphinx-copybutton`,0.5.2,MIT,Adds copy button for code blocks\ :superscript:`d 0`
+    :pypiPackages:`sphinx-issues`,3.0.1,MIT,Sphinx plugin for links to the project's Github issue tracker\ :superscript:`d 0`
+    :pypiPackages:`sphinx-tabs`,3.4.0,MIT,Sphinx plugin to create tabs\ :superscript:`d 0`
+    :pypiPackages:`sphinx_tippy`,0.4.1,MIT,Sphinx plugin to create tooltips\ :superscript:`d 0`
+    :pypiPackages:`sphinxcontrib-confluencebuilder`,2.0.0,BSD-2,Sphinx plugin to export documentation to Confluence\ :superscript:`d 0`
+    :pypiPackages:`sphinxcontrib-jquery`,4.1,BSD-0,Sphinx plugin to add JQuery\ :superscript:`d 0`
+    :pypiPackages:`sphinxcontrib-openapi`,0.8.1,BSD-2,Sphinx plugin to build OpenAPI docs\ :superscript:`d 0`
+    :pypiPackages:`sphinxemoji`,0.2.0,BSD-3,Sphinx plugin for enabling emoji\ :superscript:`d 0`
     :pypiPackages:`wheel`,latest,MIT,Support wheels for Python packages\ :superscript:`d 0`
 
 Github

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -45,12 +45,12 @@ Documentation overview
 
 The remainder of this documentation is organized as follows:
 
-* The **About** section continues to talk about the project at a high-level
-* The **Quickstart** section presents quick starts for different types of users
-* The **Libraries and API** section goes over the different libraries, APIs and tools available to users
+* The **Getting Started** section continues to talk about the project at a high-level
+* The **User Guide** section discusses how to use the server in more depth
 * The **Examples** section provides more commentary around the examples in the repository
-* The **Using the Server** section discusses how to use the server in more depth
-* The **Developers** section has useful information for contributors and more detail about the internal operations of the server
+* The **Developers** section has useful information for developers who are building their own images and compiling the server manually
+* The **About** section presents meta information about the inference server itself
+* The **Libraries and API** section goes over the different libraries, APIs and tools available to users
 
 Support
 -------

--- a/src/amdinfer/core/CMakeLists.txt
+++ b/src/amdinfer/core/CMakeLists.txt
@@ -51,6 +51,7 @@ target_include_directories(
 target_link_libraries(
   model_config PRIVATE tomlplusplus::tomlplusplus INTERFACE lib_config
 )
+add_dependencies(model_config lib_config)
 
 target_link_libraries(inference_tensor INTERFACE $<TARGET_OBJECTS:tensor>)
 target_link_libraries(

--- a/src/amdinfer/models/CMakeLists.txt
+++ b/src/amdinfer/models/CMakeLists.txt
@@ -38,32 +38,34 @@ endforeach()
 
 # create a custom target to create an entry in the repository if all these
 # targets succeed
-add_custom_target(invert_image_repository ALL)
-foreach(filename base64_encode base64_decode invert_image)
-  amdinfer_get_target_name(target ${filename})
-  add_dependencies(invert_image_repository ${target})
-endforeach()
+if(NOT AMDINFER_INSTALL)
+  add_custom_target(invert_image_repository ALL)
+  foreach(filename base64_encode base64_decode invert_image)
+    amdinfer_get_target_name(target ${filename})
+    add_dependencies(invert_image_repository ${target})
+  endforeach()
 
-add_custom_command(
-  TARGET invert_image_repository
-  POST_BUILD
-  COMMENT
-    "Copying base64_encode, base64_decode and invert_image to invert_image model in repository"
-  COMMAND mkdir -p
-          ${PROJECT_SOURCE_DIR}/external/artifacts/repository/invert_image/1
-  COMMAND
-    cp libbase64_decode.so
-    ${PROJECT_SOURCE_DIR}/external/artifacts/repository/invert_image/1/base64_decode.so
-  COMMAND
-    cp libinvert_image.so
-    ${PROJECT_SOURCE_DIR}/external/artifacts/repository/invert_image/1/invert_image.so
-  COMMAND
-    cp libbase64_encode.so
-    ${PROJECT_SOURCE_DIR}/external/artifacts/repository/invert_image/1/base64_encode.so
-  COMMAND
-    cp ${PROJECT_SOURCE_DIR}/external/repository_metadata/invert_image.toml
-    ${PROJECT_SOURCE_DIR}/external/artifacts/repository/invert_image/invert_image.toml
-)
+  add_custom_command(
+    TARGET invert_image_repository
+    POST_BUILD
+    COMMENT
+      "Copying base64_encode, base64_decode and invert_image to invert_image model in repository"
+    COMMAND mkdir -p
+            ${PROJECT_SOURCE_DIR}/external/artifacts/repository/invert_image/1
+    COMMAND
+      cp libbase64_decode.so
+      ${PROJECT_SOURCE_DIR}/external/artifacts/repository/invert_image/1/base64_decode.so
+    COMMAND
+      cp libinvert_image.so
+      ${PROJECT_SOURCE_DIR}/external/artifacts/repository/invert_image/1/invert_image.so
+    COMMAND
+      cp libbase64_encode.so
+      ${PROJECT_SOURCE_DIR}/external/artifacts/repository/invert_image/1/base64_encode.so
+    COMMAND
+      cp ${PROJECT_SOURCE_DIR}/external/repository_metadata/invert_image.toml
+      ${PROJECT_SOURCE_DIR}/external/artifacts/repository/invert_image/invert_image.toml
+  )
+endif()
 
 if(NOT SKBUILD)
   install(TARGETS ${targets} LIBRARY COMPONENT amdinfer_Runtime


### PR DESCRIPTION
# Summary of Changes

* Pin Python packages in the Dockerfile
* Fix CMake build issues

# Motivation

The "recent" update the `clang` Python package broke the container. Pinning the versions for Python is consistent with how the versions for all the other tools are pinned in the Dockerfile.

# Implementation

Using `pip freeze` to get the environment in a working container and using those versions in the Dockerfile.

There were also some small CMake fixes to add a missing dependency and fix the installation.

# Notes

Users may want to rebuild containers.
