### PR TITLE
Update benchmarks

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -63,11 +63,13 @@ Raise pull requests
 A pull request should be made against an active issue.
 An active issue indicates that it has gone through a discussion already and is approved for development.
 You can fork the repository, make your additions and raise a pull request.
-Remember to :ref:`sign your git commits <Sign your work>`_.
+Remember to :ref:`sign your git commits <sign-your-work>`.
 The pull request will be reviewed by an owner and eventually approved for testing.
 If the automated testing passes, then it can be merged in.
 All code is licensed under the terms of the LICENSE file included in the repository.
 Your contribution will be accepted under the same license.
+
+.. _sign-your-work:
 
 Sign your work
 """"""""""""""

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -205,6 +205,13 @@ exclude_patterns = [
 
 # -- Options for HTML output -------------------------------------------------
 
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+html_static_path = ["_static"]
+
+html_last_updated_fmt = "%B %d, %Y"
+
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes. Attempts to use a custom Xilinx theme if it exists,
 # otherwise the default theme is used
@@ -242,14 +249,18 @@ if os.path.exists("./_themes/xilinx"):
             (version, "/" + "inference-server/" + version + "/")
         )
 
-# Add any paths that contain custom static files (such as style sheets) here,
-# relative to this directory. They are copied after the builtin static files,
-# so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ["_static"]
+    html_css_files = [
+        "custom.css",
+        "https://cdn.datatables.net/1.13.4/css/jquery.dataTables.min.css",
+        # "https://cdn.datatables.net/fixedcolumns/4.2.2/css/fixedColumns.dataTables.min.css",
+    ]
 
-html_last_updated_fmt = "%B %d, %Y"
+    html_js_files = [
+        "https://cdn.datatables.net/1.13.4/js/jquery.dataTables.min.js",
+        # "https://cdn.datatables.net/fixedcolumns/4.2.2/js/dataTables.fixedColumns.min.js",
+        "dataTables.js",
+    ]
 
 
 def setup(app):
     app.connect("autodoc-process-signature", hide_private_module)
-    app.add_css_file("custom.css")

--- a/include/amdinfer/clients/client.hpp
+++ b/include/amdinfer/clients/client.hpp
@@ -222,7 +222,7 @@ void unloadModels(const Client* client, const std::vector<std::string>& models);
  * @return std::vector<InferenceResponse>
  */
 std::vector<InferenceResponse> inferAsyncOrdered(
-  Client* client, const std::string& model,
+  const Client* client, const std::string& model,
   const std::vector<InferenceRequest>& requests);
 /**
  * @brief Makes inference requests in parallel to the specified model in
@@ -237,7 +237,7 @@ std::vector<InferenceResponse> inferAsyncOrdered(
  * @return std::vector<InferenceResponse>
  */
 std::vector<InferenceResponse> inferAsyncOrderedBatched(
-  Client* client, const std::string& model,
+  const Client* client, const std::string& model,
   const std::vector<InferenceRequest>& requests, size_t batch_size);
 
 }  // namespace amdinfer

--- a/include/amdinfer/clients/native.hpp
+++ b/include/amdinfer/clients/native.hpp
@@ -55,7 +55,7 @@ class NativeClient : public Client {
    * @param server server to connect to
    *
    */
-  explicit NativeClient(Server* server);
+  explicit NativeClient(const Server* server);
   /// Copy constructor
   NativeClient(NativeClient const&) = delete;
   /// Copy assignment constructor

--- a/src/amdinfer/clients/client.cpp
+++ b/src/amdinfer/clients/client.cpp
@@ -119,7 +119,7 @@ void waitUntilModelNotReady(const Client* client, const std::string& model) {
 }
 
 std::vector<InferenceResponse> inferAsyncOrdered(
-  Client* client, const std::string& model,
+  const Client* client, const std::string& model,
   const std::vector<InferenceRequest>& requests) {
   std::queue<InferenceResponseFuture> q;
   for (const auto& request : requests) {
@@ -138,7 +138,7 @@ std::vector<InferenceResponse> inferAsyncOrdered(
 }
 
 std::vector<InferenceResponse> inferAsyncOrderedBatched(
-  Client* client, const std::string& model,
+  const Client* client, const std::string& model,
   const std::vector<InferenceRequest>& requests, size_t batch_size) {
   auto num_requests = requests.size();
   std::vector<InferenceResponse> responses;

--- a/src/amdinfer/clients/native.cpp
+++ b/src/amdinfer/clients/native.cpp
@@ -47,7 +47,7 @@ struct NativeClient::NativeClientImpl {
   SharedState* state;
 };
 
-NativeClient::NativeClient(Server* server) {
+NativeClient::NativeClient(const Server* server) {
   impl_ = std::make_unique<NativeClientImpl>();
   impl_->state = &(server->impl_->state);
 }

--- a/src/amdinfer/core/memory_pool/vart_tensor_allocator.cpp
+++ b/src/amdinfer/core/memory_pool/vart_tensor_allocator.cpp
@@ -62,7 +62,12 @@ BufferPtr VartTensorAllocator::get(const Tensor& tensor, size_t batch_size) {
   }
 
   auto xir_type = mapTypeToXir(datatype);
-  std::vector<int> xir_shape{shape.begin(), shape.end()};
+  std::vector<int> xir_shape;
+  xir_shape.reserve(shape.size() + 1);
+  xir_shape.push_back(static_cast<int>(batch_size));
+  for (const auto& index : shape) {
+    xir_shape.push_back(static_cast<int>(index));
+  }
   tensors_.emplace_back(xir::Tensor::create(name, xir_shape, xir_type));
   buffers_.emplace_back(tensors_.back().get());
 

--- a/src/amdinfer/workers/xmodel.cpp
+++ b/src/amdinfer/workers/xmodel.cpp
@@ -264,6 +264,9 @@ BatchPtr XModel::doRun(Batch* batch, const MemoryPool* pool) {
 
     new_batch->setModel(k, "xmodel");
   }
+  for (const auto& buffer : output_buffers) {
+    buffer->free();
+  }
   new_batch->setBuffers(std::move(new_input_buffers), {});
 
   return new_batch;

--- a/tests/performance/models/CMakeLists.txt
+++ b/tests/performance/models/CMakeLists.txt
@@ -12,13 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-list(APPEND tests resnet50)
+set(tests resnet50)
+set(libs "opencv_imgcodecs~opencv_imgproc~opencv_core~amdinfer~testing")
 
-foreach(test ${tests})
-  amdinfer_add_benchmark(${test})
-  amdinfer_get_test_target(target ${test} benchmark)
-  target_link_libraries(
-    ${target} PRIVATE opencv_imgcodecs opencv_imgproc opencv_core amdinfer
-                      testing
-  )
-endforeach()
+amdinfer_add_benchmarks(${tests} ${libs})

--- a/tools/benchmark_to_rst.py
+++ b/tools/benchmark_to_rst.py
@@ -1,0 +1,106 @@
+# Copyright 2023 Advanced Micro Devices, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import json
+
+
+def endpoint_to_name(endpoint):
+    if endpoint == "xmodel":
+        return "Vitis AI"
+    raise ValueError(f"Unknown endpoint: {endpoint}")
+
+
+def get_header(benchmark):
+    row = ["Model", "Backend"]
+
+    labels = benchmark["label"].split("/")
+    for label in labels:
+        text, value = label.split(":")
+        text = text.replace("_", " ")
+        text = " ".join([x.capitalize() for x in text.split()])
+        row.append(text)
+
+    time_unit = benchmark["time_unit"]
+    row.append(f"Time ({time_unit})")
+
+    return ",".join(row)
+
+
+def parse_benchmark(benchmark):
+    name = benchmark["name"].split("/")
+    model = name[0]
+    backend = endpoint_to_name(name[1])
+    config = name[2:]
+
+    time = benchmark["real_time"]
+
+    labels = benchmark["label"].split("/")
+    assert len(labels) == len(config)
+
+    row = [
+        model,
+        backend,
+    ]
+
+    for label in labels:
+        text, value = label.split(":")
+        # get the actual value not the requested value
+        row.append(value.split("(", 1)[0])
+
+    return ",".join(row), str(round(time, 2))
+
+
+def parse_benchmarks(json_data):
+    benchmarks = json_data["benchmarks"]
+
+    header = get_header(benchmarks[0])
+
+    rows = [header]
+    # use a dictionary to remove any duplicated rows. In case of duplicates, the
+    # last one is used
+    data = {}
+    for benchmark in benchmarks:
+        key, value = parse_benchmark(benchmark)
+        data[key] = value
+
+    for key, value in data.items():
+        rows.append(key + "," + value)
+
+    return rows
+
+
+def main(args: argparse.Namespace):
+    with open(args.file, "r") as f:
+        json_data = json.load(f)
+
+    rows = parse_benchmarks(json_data)
+
+    print("\n".join(rows))
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Convert the JSON output from Google Benchmark to an RST table"
+    )
+    parser.add_argument(
+        "-f",
+        "--file",
+        action="store",
+        default="",
+        help="path to the JSON benchmark output",
+    )
+    args = parser.parse_args()
+
+    main(args)


### PR DESCRIPTION
# Summary of Changes

* Update the ResNet50 benchmark to work for all backends

# Motivation

Having benchmarks to measure the server performance is important to find bugs and improve the performance.

# Implementation

The updated benchmark has implementations for each backend to run a ResNet50 model. Each model is run with a variety of configurations and the results can be saved as JSON. I added a script to convert this JSON output into a format that can be placed in RST for the docs. I also found and added a way to add dynamic tables in the documentation which will be useful once we add more information.

The backend implementation can be generalized once another benchmark is added. It should be generic enough that we can reuse a lot of the logic but define unique preprocessing methods to support different models.

# Notes

The benchmarks are now split by protocol. The reason for this is because HTTP (drogon) cannot be easily restarted within a process between different test runs. So each protocol is now in a separate executable which will start the server and the particular protocol once before running the benchmarks. This way, one protocol does not interfere with the others for benchmarks.
