### PR TITLE
Close dynamically opened libraries

### DIFF
--- a/include/amdinfer/core/tensor.hpp
+++ b/include/amdinfer/core/tensor.hpp
@@ -76,6 +76,8 @@ class Tensor : public Serializable {
    */
   const std::byte *deserialize(const std::byte *data_in) override;
 
+  friend std::ostream &operator<<(std::ostream &os, const Tensor &self);
+
  private:
   std::string name_;
   std::vector<uint64_t> shape_;

--- a/src/amdinfer/core/memory_pool/cpu_allocator.cpp
+++ b/src/amdinfer/core/memory_pool/cpu_allocator.cpp
@@ -66,8 +66,7 @@ BufferPtr CpuAllocator::get(const Tensor& tensor, size_t batch_size) {
   if (allocated_ + size_to_allocate > max_allocate_) {
     throw runtime_error("Too much requested");
   }
-  auto& new_block = data_.emplace_back();
-  new_block.resize(size_to_allocate);
+  auto& new_block = data_.emplace_back(size_to_allocate);
   allocated_ += size_to_allocate;
 
   auto* retval = new_block.data();

--- a/src/amdinfer/core/tensor.cpp
+++ b/src/amdinfer/core/tensor.cpp
@@ -95,4 +95,14 @@ const std::byte *Tensor::deserialize(const std::byte *data_in) {
   return data_in;
 }
 
+std::ostream &operator<<(std::ostream &os, const Tensor &self) {
+  os << "Tensor(" << self.name_ << ", [";
+  for (const auto &index : self.shape_) {
+    os << index << ",";
+  }
+  os << "], " << self.data_type_.str() << ")";
+
+  return os;
+}
+
 }  // namespace amdinfer

--- a/src/amdinfer/core/worker_info.hpp
+++ b/src/amdinfer/core/worker_info.hpp
@@ -106,6 +106,7 @@ class WorkerInfo {
 
  private:
   std::map<std::thread::id, std::thread> worker_threads_;
+  void* handle_;
   std::map<std::thread::id, workers::Worker*> workers_;
   std::vector<std::unique_ptr<Batcher>> batchers_;
   size_t batch_size_ = 1;

--- a/src/amdinfer/observation/observer.hpp
+++ b/src/amdinfer/observation/observer.hpp
@@ -44,7 +44,7 @@ inline void logTraceBuffer([[maybe_unused]] const Logger& logger, void* data,
     bytes += std::to_string(static_cast<int>(addr[i])) + ", ";
   }
   AMDINFER_LOG_TRACE(
-    logger, "Buffer(" + util::addressToString(data) + ") has bytes: " + bytes);
+    logger, "Buffer(" + util::toString(data) + ") has bytes: " + bytes);
 }
 
 #endif  // AMDINFER_ENABLE_LOGGING

--- a/src/amdinfer/servers/grpc_server.cpp
+++ b/src/amdinfer/servers/grpc_server.cpp
@@ -330,7 +330,7 @@ InferenceRequestInput getInput(
   AMDINFER_LOG_TRACE(observer.logger, "Writing " + std::to_string(size) +
                                         " elements of type " +
                                         input.getDatatype().str() + " to " +
-                                        util::addressToString(buffer->data(0)));
+                                        util::toString(buffer->data(0)));
 
   switchOverTypes(WriteData(), input.getDatatype(), buffer.get(), &req, 0, size,
                   observer);

--- a/src/amdinfer/util/string.hpp
+++ b/src/amdinfer/util/string.hpp
@@ -80,10 +80,11 @@ inline bool isLower(std::string_view str) {
                      [](char c) { return c == std::tolower(c); });
 }
 
-inline std::string addressToString(const void* ptr) {
-  std::ostringstream addr;
-  addr << ptr;
-  return addr.str();
+template <typename T>
+inline std::string toString(const T& object) {
+  std::ostringstream ss;
+  ss << object;
+  return ss.str();
 }
 
 }  // namespace amdinfer::util


### PR DESCRIPTION
# Summary of Changes

* Close shared libraries opened with `dlopen`

# Motivation

Libraries that are opened with `dlopen` should be closed when they are no longer needed.

# Implementation

Previously, I wasn't saving the handles anywhere after calling `dlopen`. In each worker, instead of opening the library object for every worker that's being loaded, it's loaded once and its handle is saved. Any other worker threads use the same handle to create a new class. Then, when the workers are being unloaded, the handle is closed at the end.

The Tfzendnn backend has extra complications because it also needs to open TF internally. Now, it opens the library first during its own construction before the other member variables are created and then it's closed during destruction.

# Notes

This investigation was motivated by the excessive memory usage observed during the resnet50 benchmark from #184 where I ran all the backends at once. Unfortunately, this issue persists still even after fixing these issues. Using the resnet50 benchmark (batch size 1, 4, 64; requests 4, 16, 64; workers 1, 2), I observed ~5Gi, ~4Gi, ~24Gi, and ~45Gi memory usage at peak for migraphx, ptzendnn, tfzendnn and xmodel, respectively, while running each backend individually. In all cases, memory usage slowly increases as the test runs.

Using `massif` on a short run doesn't show the high memory usage and it takes too long to run on a full test. I also confirmed that the memory pool is not allocating all the extra memory by logging the total allocated memory. `memcheck` showed a possible leak in `rt-engine` and other potential issues in TF/ZenDNN but it's unclear if those are enough to explain the memory usage.
