### PR TITLE
Fix wheel generation

### DIFF
--- a/docker/generate.py
+++ b/docker/generate.py
@@ -790,6 +790,7 @@ def vcpkg_build(manager):
                     nasm \\
                     pkgconfig \\
                     python3-devel \\
+                    perl-IPC-Cmd \\
                 # clean up
                 {code_indent(manager.clean, 16)}"""
         )

--- a/docker/template.dockerfile
+++ b/docker/template.dockerfile
@@ -319,6 +319,7 @@ COPY docker/.env /home/${UNAME}/
 # run any final commands before finishing the dev image
 RUN git lfs install \
     && npm install -g gh-pages \
+    && echo "/opt/vcpkg/x64-linux-dynamic/lib" > /etc/ld.so.conf.d/vcpkg.conf \
     && ldconfig
 
 $[ENTRYPOINT_DEV]

--- a/include/amdinfer/core/inference_request.hpp
+++ b/include/amdinfer/core/inference_request.hpp
@@ -81,7 +81,7 @@ class InferenceRequestInput : public InferenceTensor {
 
   /// Provides an implementation to print the class with std::cout to an ostream
   friend std::ostream &operator<<(std::ostream &os,
-                                  InferenceRequestInput const &my_class);
+                                  InferenceRequestInput const &self);
 
  private:
   void *data_ = nullptr;

--- a/include/amdinfer/core/inference_response.hpp
+++ b/include/amdinfer/core/inference_response.hpp
@@ -76,7 +76,7 @@ class InferenceResponseOutput : public InferenceTensor {
 
   /// Provides an implementation to print the class with std::cout to an ostream
   friend std::ostream &operator<<(std::ostream &os,
-                                  InferenceResponseOutput const &my_class);
+                                  InferenceResponseOutput const &self);
 
  private:
   std::vector<std::byte> data_;
@@ -133,7 +133,7 @@ class InferenceResponse {
 
   /// Provides an implementation to print the class with std::cout to an ostream
   friend std::ostream &operator<<(std::ostream &os,
-                                  InferenceResponse const &my_class);
+                                  InferenceResponse const &self);
 
  private:
   std::string model_;

--- a/include/amdinfer/core/parameters.hpp
+++ b/include/amdinfer/core/parameters.hpp
@@ -68,7 +68,7 @@ class ParameterMap : public Serializable {
    * @param key key used to store and retrieve the value
    * @param value value to store
    */
-  void put(const std::string &key, Parameter value);
+  void put(const std::string &key, const Parameter &value);
   /**
    * @brief Put in a key-value pair
    *

--- a/setup.py
+++ b/setup.py
@@ -125,6 +125,11 @@ skbuild.setup(
     package_dir={"": str(package)},
     include_package_data=True,
     cmake_install_dir=str(package / "amdinfer"),
+    cmake_args=[
+        "-DCMAKE_TOOLCHAIN_FILE=/opt/vcpkg/vcpkg/scripts/buildsystems/vcpkg.cmake",
+        "-DVCPKG_TARGET_TRIPLET=x64-linux-dynamic",
+        "-DVCPKG_INSTALLED_DIR=/opt/vcpkg",
+    ],
     package_data={
         "": [
             "*.pyi",

--- a/src/amdinfer/batching/soft.cpp
+++ b/src/amdinfer/batching/soft.cpp
@@ -109,7 +109,7 @@ void SoftBatcher::doRun(const std::vector<MemoryAllocators>& allocators) {
       }
 
       auto request = req->request;
-      auto& inputs = request->getInputs();
+      const auto& inputs = request->getInputs();
       auto input_size = inputs.size();
       if (input_size == 0) {
         request->runCallbackError("Input size is zero");

--- a/src/amdinfer/bindings/python/core/parameters.cpp
+++ b/src/amdinfer/bindings/python/core/parameters.cpp
@@ -52,7 +52,8 @@ void wrapParameterMap(py::module_ &m) {
       py::overload_cast<const std::string &, const char *>(&ParameterMap::put),
       DOCS(ParameterMap, put))
     .def("put",
-         py::overload_cast<const std::string &, Parameter>(&ParameterMap::put),
+         py::overload_cast<const std::string &, const Parameter &>(
+           &ParameterMap::put),
          DOCS(ParameterMap, put))
     .def("getBool", &ParameterMap::get<bool>, DOCS(ParameterMap, get))
     .def("getFloat", &ParameterMap::get<double>, DOCS(ParameterMap, get))

--- a/src/amdinfer/buffers/cpu.cpp
+++ b/src/amdinfer/buffers/cpu.cpp
@@ -33,7 +33,7 @@ CpuBuffer::CpuBuffer(void* data, MemoryAllocators allocator)
 void* CpuBuffer::data(size_t offset) { return data_ + offset; }
 
 void CpuBuffer::free() {
-  auto* pool = getPool();
+  const auto* pool = getPool();
   if (pool != nullptr) {
     pool->put(getAllocator(), data_);
   }

--- a/src/amdinfer/buffers/vart_tensor.cpp
+++ b/src/amdinfer/buffers/vart_tensor.cpp
@@ -58,7 +58,7 @@ void* VartTensorBuffer::data(size_t offset) {
 vart::TensorBuffer* VartTensorBuffer::getTensorBuffer() { return data_; }
 
 void VartTensorBuffer::free() {
-  auto* pool = getPool();
+  const auto* pool = getPool();
   if (pool != nullptr) {
     pool->put(getAllocator(), data_);
   }

--- a/src/amdinfer/clients/grpc_internal.cpp
+++ b/src/amdinfer/clients/grpc_internal.cpp
@@ -247,7 +247,7 @@ void mapResponseToProto(InferenceResponse response,
     tensor->set_datatype(output.getDatatype().str());
     const auto& shape = output.getShape();
     auto size = 1U;
-    for (const size_t& index : shape) {
+    for (const auto& index : shape) {
       tensor->add_shape(index);
       size *= index;
     }

--- a/src/amdinfer/clients/http_internal.cpp
+++ b/src/amdinfer/clients/http_internal.cpp
@@ -172,8 +172,6 @@ Json::Value mapRequestToJson(const InferenceRequest &request) {
   return json;
 }
 
-using drogon::HttpStatusCode;
-
 #ifdef AMDINFER_ENABLE_TRACING
 void propagate(drogon::HttpResponse *resp, const StringMap &context) {
   for (const auto &[key, value] : context) {

--- a/src/amdinfer/core/inference_request.cpp
+++ b/src/amdinfer/core/inference_request.cpp
@@ -141,19 +141,18 @@ const std::byte *InferenceRequestInput::deserialize(const std::byte *data_in) {
   return util::copy(data_in, static_cast<std::byte *>(data_), metadata.data);
 }
 
-std::ostream &operator<<(std::ostream &os,
-                         InferenceRequestInput const &my_class) {
+std::ostream &operator<<(std::ostream &os, InferenceRequestInput const &self) {
   os << "InferenceRequestInput:\n";
-  os << "  Name: " << my_class.getName() << "\n";
+  os << "  Name: " << self.getName() << "\n";
   os << "  Shape: ";
-  for (const auto &index : my_class.getShape()) {
+  for (const auto &index : self.getShape()) {
     os << index << ",";
   }
   os << "\n";
-  os << "  Datatype: " << my_class.getDatatype().str() << "\n";
+  os << "  Datatype: " << self.getDatatype().str() << "\n";
   os << "  Parameters:\n";
-  os << my_class.getParameters() << "\n";
-  os << "  Data: " << my_class.getData() << "\n";
+  os << self.getParameters() << "\n";
+  os << "  Data: " << self.getData() << "\n";
   return os;
 }
 

--- a/src/amdinfer/core/model_config.cpp
+++ b/src/amdinfer/core/model_config.cpp
@@ -28,8 +28,6 @@
 #include "amdinfer/util/filesystem.hpp"
 #include "model_config.pb.h"  // for Config, InferP...
 
-namespace fs = std::filesystem;
-
 namespace amdinfer {
 
 std::string extractString(const toml::table& table, const std::string& key,
@@ -37,9 +35,8 @@ std::string extractString(const toml::table& table, const std::string& key,
   if (!table.contains(key)) {
     if (is_required) {
       throw invalid_argument("The configuration must have a " + key);
-    } else {
-      return "";
     }
+    return "";
   }
 
   const auto& node = table.at(key);
@@ -56,7 +53,7 @@ ModelConfigData extractConfig(const toml::table& table, bool is_ensemble);
 // if we're not explicitly handling the types, use this to catch the failure at
 // compile time
 template <class...>
-constexpr std::false_type templated_false{};
+constexpr std::false_type kTemplatedFalse{};
 
 template <typename T>
 std::vector<T> extractArray(const toml::table& table, const std::string& key) {
@@ -98,7 +95,7 @@ std::vector<T> extractArray(const toml::table& table, const std::string& key) {
       const auto& tbl = *element.as_table();
       vector.push_back(extractConfig(tbl, true));
     } else {
-      static_assert(templated_false<T>);
+      static_assert(kTemplatedFalse<T>);
     }
   }
 
@@ -167,9 +164,8 @@ void ModelConfig::createModels() {
       parameters.put("worker", "tfzendnn");
     } else if (config.platform == "pytorch_torchscript") {
       parameters.put("worker", "ptzendnn");
-    } else if (config.platform == "onnx_onnxv1") {
-      parameters.put("worker", "migraphx");
-    } else if (config.platform == "migraphx_mxr") {
+    } else if (config.platform == "onnx_onnxv1" ||
+               config.platform == "migraphx_mxr") {
       parameters.put("worker", "migraphx");
     } else if (config.platform == "vitis_xmodel") {
       parameters.put("worker", "xmodel");

--- a/src/amdinfer/core/model_config.hpp
+++ b/src/amdinfer/core/model_config.hpp
@@ -77,7 +77,7 @@ class ModelConfig {
   using ConstReverseIterator = Container::const_reverse_iterator;
 
  public:
-  ModelConfig(const toml::v3::table& config, const std::string& version);
+  ModelConfig(const toml::v3::table& toml, const std::string& version);
   ModelConfig(const inference::Config& config, const std::string& version);
 
   std::pair<std::string, ParameterMap> get(size_t index);

--- a/src/amdinfer/core/model_repository.cpp
+++ b/src/amdinfer/core/model_repository.cpp
@@ -114,7 +114,8 @@ ModelConfig openConfigFile(const fs::path& config_path,
     }
 
     return ModelConfig{proto_config, version};
-  } else if (config_path.extension() == ".toml") {
+  }
+  if (config_path.extension() == ".toml") {
     auto toml = toml::parse_file(config_path.string());
 
     return ModelConfig{toml, version};

--- a/src/amdinfer/core/parameters.cpp
+++ b/src/amdinfer/core/parameters.cpp
@@ -43,8 +43,8 @@ ParameterMap::ParameterMap(const std::vector<std::string> &keys,
   }
 }
 
-void ParameterMap::put(const std::string &key, Parameter value) {
-  auto [iter, emplaced] = this->parameters_.try_emplace(key, std::move(value));
+void ParameterMap::put(const std::string &key, const Parameter &value) {
+  auto [iter, emplaced] = this->parameters_.try_emplace(key, value);
   if (!emplaced) {
     iter->second = value;
   }

--- a/src/amdinfer/core/worker_info.cpp
+++ b/src/amdinfer/core/worker_info.cpp
@@ -109,8 +109,8 @@ workers::Worker* getWorker(void* handle) {
 
 WorkerInfo::WorkerInfo(const std::string& name, ParameterMap* parameters,
                        MemoryPool* pool, BatchPtrQueue* next,
-                       const std::vector<MemoryAllocators>& next_allocators)
-  : next_(next), next_allocators_(next_allocators) {
+                       std::vector<MemoryAllocators> next_allocators)
+  : next_(next), next_allocators_(std::move(next_allocators)) {
   handle_ = getHandle(name);
   this->addAndStartWorker(name, parameters, pool);
 }

--- a/src/amdinfer/core/worker_info.hpp
+++ b/src/amdinfer/core/worker_info.hpp
@@ -54,7 +54,7 @@ class WorkerInfo {
   /// Construct a new WorkerInfo object
   WorkerInfo(const std::string& name, ParameterMap* parameters,
              MemoryPool* pool, BatchPtrQueue* next,
-             const std::vector<MemoryAllocators>& next_allocators);
+             std::vector<MemoryAllocators> next_allocators);
   ~WorkerInfo();                           ///> Destroy a WorkerInfo object
   WorkerInfo(WorkerInfo const&) = delete;  ///< Copy constructor
   /// Copy assignment constructor
@@ -106,7 +106,7 @@ class WorkerInfo {
 
  private:
   std::map<std::thread::id, std::thread> worker_threads_;
-  void* handle_;
+  void* handle_ = nullptr;
   std::map<std::thread::id, workers::Worker*> workers_;
   std::vector<std::unique_ptr<Batcher>> batchers_;
   size_t batch_size_ = 1;

--- a/src/amdinfer/models/base64_decode.cpp
+++ b/src/amdinfer/models/base64_decode.cpp
@@ -63,7 +63,7 @@ amdinfer::BatchPtr run(amdinfer::Batch* batch) {
       req->runCallbackError("Only one input tensor should be present");
       continue;
     }
-    auto& input = inputs.at(0);
+    const auto& input = inputs.at(0);
     const auto& input_shape = input.getShape();
     auto input_size = amdinfer::util::containerProduct(input_shape);
 

--- a/src/amdinfer/models/base64_encode.cpp
+++ b/src/amdinfer/models/base64_encode.cpp
@@ -62,7 +62,7 @@ amdinfer::BatchPtr run(amdinfer::Batch* batch) {
       req->runCallbackError("Only one input tensor should be present");
       continue;
     }
-    auto& input = inputs.at(0);
+    const auto& input = inputs.at(0);
     auto input_shape = input.getShape();
 
     auto new_request = req->propagate();

--- a/src/amdinfer/servers/http_server.cpp
+++ b/src/amdinfer/servers/http_server.cpp
@@ -143,7 +143,7 @@ Json::Value parseResponse(InferenceResponse response) {
     json_output["shape"] = Json::arrayValue;
     json_output["datatype"] = output.getDatatype().str();
     const auto &shape = output.getShape();
-    for (const size_t &index : shape) {
+    for (const auto &index : shape) {
       json_output["shape"].append(static_cast<Json::UInt>(index));
     }
 

--- a/src/amdinfer/workers/aks_detect_stream.cpp
+++ b/src/amdinfer/workers/aks_detect_stream.cpp
@@ -330,6 +330,7 @@ BatchPtr AksDetectStream::doRun(Batch* batch,
           output.setName("image");
           output.setDatatype(DataType::Bytes);
           auto message = constructMessage(key, frames.front(), labels[j]);
+          std::vector<std::byte> buffer;
           buffer.resize(message.size());
           memcpy(buffer.data(), message.data(), message.size());
           output.setData(std::move(buffer));

--- a/src/amdinfer/workers/c_plus_plus.cpp
+++ b/src/amdinfer/workers/c_plus_plus.cpp
@@ -50,11 +50,6 @@
 
 namespace amdinfer {
 
-const int kInputTensors = 2;
-const std::array<int, kInputTensors> kInputLengths = {1, 2};
-const int kOutputTensors = 3;
-const std::array<int, kOutputTensors> kOutputLengths = {1, 4, 3};
-
 // TODO(varunsh): delete with duplicate in worker_info.cpp
 void* openModel(const std::string& so_path) {
   if (so_path.empty()) {
@@ -116,7 +111,7 @@ class CPlusPlus : public SingleThreadedWorker {
   void doRelease() override;
   void doDestroy() override;
 
-  void* handle_;
+  void* handle_ = nullptr;
   std::vector<Tensor> input_tensors_;
   std::vector<Tensor> output_tensors_;
 

--- a/src/amdinfer/workers/invert_video.cpp
+++ b/src/amdinfer/workers/invert_video.cpp
@@ -168,6 +168,7 @@ BatchPtr InvertVideo::doRun(Batch* batch,
         output.setName("image");
         output.setDatatype(DataType::Bytes);
         message = constructMessage(key, encoded);
+        std::vector<std::byte> buffer;
         buffer.resize(message.size());
         memcpy(buffer.data(), message.data(), message.size());
         output.setData(std::move(buffer));

--- a/src/amdinfer/workers/migraphx.cpp
+++ b/src/amdinfer/workers/migraphx.cpp
@@ -153,9 +153,9 @@ void MIGraphXWorker::compile(const std::string& onnx_path,
   // Load the onnx file
   // Using parse_onnx() instead of load() because there's a bug at the
   // time of writing
-  AMDINFER_LOG_INFO(logger,
-                    std::string("migraphx worker loading ONNX model file ") +
-                      onnx_path.c_str());
+  AMDINFER_LOG_INFO(
+    logger,
+    std::string("migraphx worker loading ONNX model file ") + onnx_path);
 
   migraphx::onnx_options onnx_opts;
   onnx_opts.set_default_dim_value(static_cast<unsigned int>(batch_size_));
@@ -164,9 +164,8 @@ void MIGraphXWorker::compile(const std::string& onnx_path,
   auto param_shapes =
     prog_.get_parameter_shapes();  // program_parameter_shapes struct
 
-  AMDINFER_LOG_INFO(
-    logger,
-    std::string("migraphx worker loaded ONNX model file ") + onnx_path.c_str());
+  AMDINFER_LOG_INFO(logger,
+                    "migraphx worker loaded ONNX model file " + onnx_path);
 
   // Compile the model.  Hard-coded choices of offload_copy and gpu target
   migraphx::compile_options comp_opts;
@@ -197,8 +196,7 @@ void MIGraphXWorker::compile(const std::string& onnx_path,
     options.set_file_format("msgpack");
 
     migraphx::save(this->prog_, compiled_path.c_str(), options);
-    AMDINFER_LOG_INFO(logger, std::string(" Saved compiled model file ") +
-                                compiled_path.c_str());
+    AMDINFER_LOG_INFO(logger, " Saved compiled model file " + compiled_path);
   }
 }
 

--- a/src/amdinfer/workers/responder.cpp
+++ b/src/amdinfer/workers/responder.cpp
@@ -45,14 +45,7 @@
 #include "amdinfer/util/timer.hpp"           // for Timer
 #include "amdinfer/workers/worker.hpp"       // for Worker
 
-namespace amdinfer {
-
-const int kInputTensors = 2;
-const std::array<int, kInputTensors> kInputLengths = {1, 2};
-const int kOutputTensors = 3;
-const std::array<int, kOutputTensors> kOutputLengths = {1, 4, 3};
-
-namespace workers {
+namespace amdinfer::workers {
 
 /**
  * @brief The Responder worker can run a compiled C++ "model".
@@ -162,9 +155,7 @@ BatchPtr Responder::doRun(Batch* batch,
 void Responder::doRelease() {}
 void Responder::doDestroy() {}
 
-}  // namespace workers
-
-}  // namespace amdinfer
+}  // namespace amdinfer::workers
 
 extern "C" {
 // using smart pointer here may cause problems inside shared object so managing

--- a/tests/performance/models/benchmark_resnet50.cpp
+++ b/tests/performance/models/benchmark_resnet50.cpp
@@ -42,8 +42,6 @@
 #include "amdinfer/pre_post/image_preprocess.hpp"  // for ImagePreprocessOpt...
 #include "amdinfer/testing/get_path_to_asset.hpp"  // for getPathToAsset
 
-namespace fs = std::filesystem;
-
 using InferenceRequest = amdinfer::InferenceRequest;
 using ParameterMap = amdinfer::ParameterMap;
 
@@ -59,12 +57,12 @@ class Config {
       requests_(requests),
       workers_(workers) {}
 
-  int requests() const { return requests_; }
-  int batchSize() const { return batch_size_.first; }
+  [[nodiscard]] int requests() const { return requests_; }
+  [[nodiscard]] int batchSize() const { return batch_size_.first; }
   void batchSize(int batch_size) { batch_size_.second = batch_size; }
-  int workers() const { return workers_; }
+  [[nodiscard]] int workers() const { return workers_; }
 
-  std::string toString() const {
+  [[nodiscard]] std::string toString() const {
     return "batch_size:" + std::to_string(batch_size_.second) + "(" +
            std::to_string(batch_size_.first) +
            ")/requests:" + std::to_string(requests_) +
@@ -91,14 +89,14 @@ class Backend {
 
   virtual void preprocess(const std::string& input_path) = 0;
 
-  virtual std::string extension() const = 0;
-  virtual std::string name() const = 0;
+  [[nodiscard]] virtual std::string extension() const = 0;
+  [[nodiscard]] virtual std::string name() const = 0;
   virtual void updateConfig(Config& config) = 0;
 
   void request(InferenceRequest request) { request_ = std::move(request); }
-  const InferenceRequest& request() const { return request_; }
+  [[nodiscard]] const InferenceRequest& request() const { return request_; }
 
-  const auto& parameters() const { return parameters_; }
+  [[nodiscard]] const auto& parameters() const { return parameters_; }
   void put(const std::string& key, const amdinfer::Parameter& value) {
     parameters_.put(key, value);
   }
@@ -123,8 +121,8 @@ class Ptzendnn : public Backend {
     this->put("model", model);
   }
 
-  std::string name() const override { return "ptzendnn"; }
-  std::string extension() const override { return "ptzendnn"; }
+  [[nodiscard]] std::string name() const override { return "ptzendnn"; }
+  [[nodiscard]] std::string extension() const override { return "ptzendnn"; }
   void updateConfig([[maybe_unused]] Config& config) override {
     // no update necessary
   }
@@ -177,8 +175,8 @@ class Tfzendnn : public Backend {
     put("intra_op", 1);
   }
 
-  std::string name() const override { return "tfzendnn"; }
-  std::string extension() const override { return "tfzendnn"; }
+  [[nodiscard]] std::string name() const override { return "tfzendnn"; }
+  [[nodiscard]] std::string extension() const override { return "tfzendnn"; }
   void updateConfig([[maybe_unused]] Config& config) override {
     // no update necessary
   }
@@ -211,8 +209,8 @@ class Vitis : public Backend {
     put("model", model);
   }
 
-  std::string name() const override { return "xmodel"; }
-  std::string extension() const override { return "vitis"; }
+  [[nodiscard]] std::string name() const override { return "xmodel"; }
+  [[nodiscard]] std::string extension() const override { return "vitis"; }
   void updateConfig(Config& config) override {
     const int batch_size = 4;
     config.batchSize(batch_size);
@@ -249,8 +247,8 @@ class Migraphx : public Backend {
     put("model", model);
   }
 
-  std::string name() const override { return "migraphx"; }
-  std::string extension() const override { return "migraphx"; }
+  [[nodiscard]] std::string name() const override { return "migraphx"; }
+  [[nodiscard]] std::string extension() const override { return "migraphx"; }
   void updateConfig([[maybe_unused]] Config& config) override {
     // no update necessary
   }
@@ -372,7 +370,7 @@ void resnet50(benchmark::State& st, const amdinfer::Client* client,
   const std::vector<amdinfer::InferenceRequest> requests{
     static_cast<size_t>(config.requests()), request};
 
-  for (auto _ : st) {
+  for ([[maybe_unused]] auto _ : st) {
     std::ignore = amdinfer::inferAsyncOrdered(client, endpoint, requests);
   }
   for (auto i = 0; i < workers; ++i) {

--- a/tests/src/amdinfer/core/worker_info_buffers_finite.cpp
+++ b/tests/src/amdinfer/core/worker_info_buffers_finite.cpp
@@ -37,8 +37,8 @@ namespace amdinfer {
 
 WorkerInfo::WorkerInfo(const std::string& name, ParameterMap* parameters,
                        MemoryPool* pool, BatchPtrQueue* next,
-                       const std::vector<MemoryAllocators>& next_allocators)
-  : next_(next), next_allocators_(next_allocators) {
+                       std::vector<MemoryAllocators> next_allocators)
+  : next_(next), next_allocators_(std::move(next_allocators)) {
   this->batch_size_ = 1;
 
   this->addAndStartWorker(name, parameters, pool);

--- a/tests/src/amdinfer/core/worker_info_buffers_infinite.cpp
+++ b/tests/src/amdinfer/core/worker_info_buffers_infinite.cpp
@@ -36,8 +36,8 @@ namespace amdinfer {
 
 WorkerInfo::WorkerInfo(const std::string& name, ParameterMap* parameters,
                        MemoryPool* pool, BatchPtrQueue* next,
-                       const std::vector<MemoryAllocators>& next_allocators)
-  : next_(next), next_allocators_(next_allocators) {
+                       std::vector<MemoryAllocators> next_allocators)
+  : next_(next), next_allocators_(std::move(next_allocators)) {
   this->batch_size_ = 1;
 
   this->addAndStartWorker(name, parameters, pool);

--- a/tests/unit/core/test_model_config.cpp
+++ b/tests/unit/core/test_model_config.cpp
@@ -26,7 +26,7 @@ namespace amdinfer {
 
 // NOLINTNEXTLINE(cert-err58-cpp, cppcoreguidelines-owning-memory)
 TEST(UnitModelConfig, Basic) {
-  constexpr std::string_view toml_str = R"(
+  constexpr std::string_view kTomlStr = R"(
     name = "mnist"
     platform = "tensorflow_graphdef"
 
@@ -41,7 +41,7 @@ TEST(UnitModelConfig, Basic) {
     shape = [10]
   )"sv;
 
-  const auto toml = toml::parse(toml_str);
+  const auto toml = toml::parse(kTomlStr);
   ModelConfig config{toml, ""};
 
   ASSERT_EQ(config.size(), 1);
@@ -53,7 +53,7 @@ TEST(UnitModelConfig, Basic) {
 
 // NOLINTNEXTLINE(cert-err58-cpp, cppcoreguidelines-owning-memory)
 TEST(UnitModelConfig, SingleEnsemble) {
-  constexpr std::string_view toml_str = R"(
+  constexpr std::string_view kTomlStr = R"(
     [[models]]
     name = "mnist"
     platform = "tensorflow_graphdef"
@@ -72,7 +72,7 @@ TEST(UnitModelConfig, SingleEnsemble) {
     id = "classes"
   )"sv;
 
-  const auto toml = toml::parse(toml_str);
+  const auto toml = toml::parse(kTomlStr);
   ModelConfig config{toml, ""};
 
   ASSERT_EQ(config.size(), 1);
@@ -84,7 +84,7 @@ TEST(UnitModelConfig, SingleEnsemble) {
 
 // NOLINTNEXTLINE(cert-err58-cpp, cppcoreguidelines-owning-memory)
 TEST(UnitModelConfig, Chain) {
-  constexpr std::string_view toml_str = R"(
+  constexpr std::string_view kTomlStr = R"(
     [[models]]
     name = "invert_image"
     platform = "amdinfer_cpp"
@@ -137,7 +137,7 @@ TEST(UnitModelConfig, Chain) {
     id = "postprocessed_image"
   )"sv;
 
-  const auto toml = toml::parse(toml_str);
+  const auto toml = toml::parse(kTomlStr);
   const std::string version{"1"};
   ModelConfig config{toml, version};
 

--- a/tests/unit/core/test_parameter_map.cpp
+++ b/tests/unit/core/test_parameter_map.cpp
@@ -82,6 +82,7 @@ TEST(UnitParameterMap, InitializingConstructorConstChar) {
   // string if both types are present. This has been fixed in C++20
   // (https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2018/p0608r3.html)
   std::string model;
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto, hicpp-avoid-goto)
   EXPECT_THROW_CHECK(model = parameters.get<std::string>("model");
                      , EXPECT_STREQ(e.what(), "Unexpected index"),
                      std::bad_variant_access);

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -157,6 +157,10 @@
     {
       "name": "trantor",
       "version": "1.5.11#2"
+    },
+    {
+      "name": "vcpkg-tool-meson",
+      "version": "0.60.2"
     }
   ],
   "vcpkg-configuration": {


### PR DESCRIPTION
# Summary of Changes

* Fix generating wheels when using vcpkg

# Motivation

We need to be able to build Python wheels.

# Implementation

Here are the fixes applied:

* Pin `vcpkg-tool-meson` version to 0.60.2: Versions of meson past 0.62.0 require Python 3.7+. However, for wheel building, the environment has Python 3.6 which fails to build some packages.
* Add some missing packages using yum: `perl-IPC-Cmd`
* Add vcpkg libraries to linker path: it was previously only set for the deployment image. Now it's also configured for the development image
* Add the CMake toolchain file for vcpkg to skbuild

# Notes

For now, the CMake toolchain paths have been hardcoded in `setup.py`. It may need to be generalized later.
