### PR TITLE
Allow passing git credentials to Docker build

### DIFF
--- a/docker/template.dockerfile
+++ b/docker/template.dockerfile
@@ -299,9 +299,7 @@ RUN mkdir /opt/vcpkg \
     && ./bootstrap-vcpkg.sh -disableMetrics \
     && rm /opt/vcpkg/2023.04.15.tar.gz \
     && cd /tmp \
-    && export GIT_USER="$GIT_USER" \
-    && export GIT_TOKEN="$GIT_TOKEN" \
-    && ./docker/install_vcpkg.sh --vitis ${ENABLE_VITIS}
+    && GIT_USER="${GIT_USER}" GIT_TOKEN="${GIT_TOKEN}" ./docker/install_vcpkg.sh --vitis ${ENABLE_VITIS}
 
 FROM migraphx_installer_${ENABLE_MIGRAPHX} AS dev
 

--- a/docker/template.dockerfile
+++ b/docker/template.dockerfile
@@ -45,6 +45,9 @@ ARG ENABLE_PTZENDNN=${ENABLE_PTZENDNN:-no}
 ARG PTZENDNN_PATH
 ARG ENABLE_MIGRAPHX=${ENABLE_MIGRAPHX:-no}
 
+ARG GIT_USER
+ARG GIT_TOKEN
+
 # this stage adds development tools such as compilers to the base image. It's
 # used as an ancestor for all development-related stages
 FROM ${BASE_IMAGE} AS dev_base
@@ -275,6 +278,8 @@ FROM migraphx_installer_${ENABLE_MIGRAPHX} AS vcpkg_builder
 
 ARG ENABLE_VITIS
 ARG COPY_DIR
+ARG GIT_USER
+ARG GIT_TOKEN
 WORKDIR /tmp
 
 $[VCPKG_BUILD]
@@ -294,6 +299,8 @@ RUN mkdir /opt/vcpkg \
     && ./bootstrap-vcpkg.sh -disableMetrics \
     && rm /opt/vcpkg/2023.04.15.tar.gz \
     && cd /tmp \
+    && export GIT_USER="$GIT_USER" \
+    && export GIT_TOKEN="$GIT_TOKEN" \
     && ./docker/install_vcpkg.sh --vitis ${ENABLE_VITIS}
 
 FROM migraphx_installer_${ENABLE_MIGRAPHX} AS dev


### PR DESCRIPTION
# Summary of Changes

* Allow passing git credentials to Docker build 

# Motivation

If there are private git repos or repos that need credentials in the vcpkg build, then those credentials are needed at the build stage or the image cannot be built.

# Implementation

I added two build variables: GIT_USER and GIT_TOKEN. These can be set from the command line when invoking the docker build. Then, they're set in the shell when vcpkg build in called. To use them in the vcpkg build, use something like `https://$ENV{GIT_USER}:$ENV{GIT_TOKEN}@<url>.git` in the `portfile.cmake` when cloning the git repo.

# Notes

N/A
