### PR TITLE
Fix loading models at startup

### DIFF
--- a/src/amdinfer/core/model_repository.cpp
+++ b/src/amdinfer/core/model_repository.cpp
@@ -147,13 +147,15 @@ void ModelRepository::setRepository(const fs::path& repository_path,
     AMDINFER_IF_LOGGING(Logger logger{Loggers::Server};)
     for (const auto& path : fs::directory_iterator(repository_)) {
       if (path.is_directory()) {
-        auto model = path.path().filename();
+        auto model_name = path.path().filename();
         try {
-          ParameterMap params;
-          endpoints_->load(model, "", params);
+          auto config = parseModel(repository_, model_name, "");
+          for (const auto& [model, parameters] : config) {
+            endpoints_->load(model, "", parameters);
+          }
         } catch (const amdinfer::runtime_error& e) {
           AMDINFER_LOG_INFO(
-            logger, "Error loading " + model.string() + ": " + e.what());
+            logger, "Error loading " + model_name.string() + ": " + e.what());
         }
       }
     }

--- a/src/amdinfer/core/model_repository.cpp
+++ b/src/amdinfer/core/model_repository.cpp
@@ -140,6 +140,14 @@ ModelConfig parseModel(const fs::path& repository, const std::string& model,
   return config;
 }
 
+void loadModel(const fs::path& repository, const fs::path& model_name,
+               Endpoints* endpoints) {
+  auto config = parseModel(repository, model_name, "");
+  for (const auto& [model, parameters] : config) {
+    endpoints->load(model, "", parameters);
+  }
+}
+
 void ModelRepository::setRepository(const fs::path& repository_path,
                                     bool load_existing) {
   repository_ = repository_path;
@@ -149,10 +157,7 @@ void ModelRepository::setRepository(const fs::path& repository_path,
       if (path.is_directory()) {
         auto model_name = path.path().filename();
         try {
-          auto config = parseModel(repository_, model_name, "");
-          for (const auto& [model, parameters] : config) {
-            endpoints_->load(model, "", parameters);
-          }
+          loadModel(repository_, model_name, endpoints_);
         } catch (const amdinfer::runtime_error& e) {
           AMDINFER_LOG_INFO(
             logger, "Error loading " + model_name.string() + ": " + e.what());
@@ -187,10 +192,7 @@ void UpdateListener::handleFileAction(
       std::this_thread::sleep_for(delay);
       auto model_name = fs::path(dir).parent_path().filename();
       try {
-        auto config = parseModel(repository_, model_name, "");
-        for (const auto& [model, parameters] : config) {
-          endpoints_->load(model, "", parameters);
-        }
+        loadModel(repository_, model_name, endpoints_);
       } catch (const runtime_error&) {
         AMDINFER_LOG_INFO(logger, "Error loading " + model_name.string());
       }


### PR DESCRIPTION
# Summary of Changes

* Fix loading models at startup

# Motivation

This bug prevents loading models at startup in the deployment container.

# Implementation

I implemented loading models correctly (by using the `parseModel` function to handle ensembles) for the file watcher but the same change was not in the function that's invoked when the server loads the repository at startup.

# Notes

The problem was being masked when Vitis was enabled because there's a worker that's also named resnet50 which matches the quickstart instructions to load from a repository with resnet50.
