### PR TITLE
Update documentation

### DIFF
--- a/docker/generate.py
+++ b/docker/generate.py
@@ -644,6 +644,7 @@ def install_python_packages():
     #         sphinxemoji \
     #         sphinx-issues \
     #         exhale \
+    #         sphinx-favicon \
     #         sphinx-tabs \
     #         sphinx-tippy \
     #         sphinxcontrib-openapi \
@@ -738,6 +739,7 @@ def install_python_packages():
                 "sphinx-argparse==0.4.0" \\
                 "sphinx-charts==0.2.1" \\
                 "sphinx-copybutton==0.5.2" \\
+                "sphinx-favicon==1.0.1" \\
                 "sphinx-issues==3.0.1" \\
                 "sphinx-tabs==3.4.0" \\
                 "sphinx_mdinclude==0.5.3" \\

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -74,6 +74,7 @@ extensions = [
     "sphinxemoji.sphinxemoji",
     "sphinxcontrib.openapi",
     "sphinx_charts.charts",
+    "sphinx_favicon",
 ]
 
 # Breathe configuration
@@ -213,15 +214,28 @@ html_static_path = ["_static"]
 
 html_last_updated_fmt = "%B %d, %Y"
 
+favicons = [
+    {"rel": "apple-touch-icon", "sizes": "180x180", "href": "apple-touch-icon.png"},
+    {"rel": "icon", "type": "image/png", "sizes": "32x32", "href": "favicon-32x32.png"},
+    {"rel": "icon", "type": "image/png", "sizes": "16x16", "href": "favicon-16x16.png"},
+    {"rel": "manifest", "href": "site.webmanifest"},
+    {"rel": "mask-icon", "href": "safari-pinned-tab.svg", "color": "#5bbad5"},
+    {"name": "msapplication-TileColor", "content": "#ed1c24"},
+    {"name": "theme-color", "content": "#ed1c24"},
+]
+
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes. Attempts to use a custom Xilinx theme if it exists,
 # otherwise the default theme is used
 #
 if os.path.exists("./_themes/xilinx"):
+    html_title = "AMD Inference Server"
+    html_logo = "_static/xilinx-header-logo.svg"
     html_theme = "xilinx"
     html_theme_path = ["./_themes"]
-    html_favicon = "./_themes/xilinx/favicon.ico"
     html_theme_options = {
+        "logo_only": False,
+        "style_nav_header_background": "black",
         # set to true to hide the expand buttons on headings in the sidebar
         # until the heading is clicked on
         "collapse_navigation": False,

--- a/docs/dry.rst
+++ b/docs/dry.rst
@@ -61,13 +61,16 @@ In this case, the endpoint is defined in the model's configuration file in the r
 
     .. code-tab:: console CPU
 
-        $ docker pull amdih/serve:uif1.1_zendnn_amdinfer_0.3.0
+        # this image is not available on Dockerhub yet but you can build it yourself from the repository
+        $ docker pull amdih/serve:uif1.1_zendnn_amdinfer_0.4.0
 
     .. code-tab:: text GPU
 
-        $ docker pull amdih/serve:uif1.1_migraphx_amdinfer_0.3.0
+        # this image is not available on Dockerhub yet but you can build it yourself from the repository
+        $ docker pull amdih/serve:uif1.1_migraphx_amdinfer_0.4.0
 
     .. code-tab:: console FPGA
 
-        # this image is not currently pre-built but you can build it yourself
+        # this image is not available on Dockerhub yet but you can build it yourself from the repository
+        $ docker pull amdih/serve:uif1.1_vai_amdinfer_0.4.0
 -docker_pull_deployment_images

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -173,15 +173,15 @@ The flags used in this sample command are:
 
     .. code-tab:: console CPU
 
-        $ docker run -d --volume $(pwd)/model_repository:/mnt/models:rw --net=host amdih/serve:uif1.1_zendnn_amdinfer_0.3.0
+        $ docker run -d --volume $(pwd)/model_repository:/mnt/models:rw --net=host amdih/serve:uif1.1_zendnn_amdinfer_0.4.0
 
     .. code-tab:: console GPU
 
-        $ docker run -d --device /dev/kfd --device /dev/dri --volume $(pwd)/model_repository:/mnt/models:rw --publish 127.0.0.1::8998 --publish 127.0.0.1::50051 amdih/serve:uif1.1_migraphx_amdinfer_0.3.0
+        $ docker run -d --device /dev/kfd --device /dev/dri --volume $(pwd)/model_repository:/mnt/models:rw --publish 127.0.0.1::8998 --publish 127.0.0.1::50051 amdih/serve:uif1.1_migraphx_amdinfer_0.4.0
 
     .. code-tab:: console FPGA
 
-        $ docker run -d --device /dev/dri --device /dev/xclmgmt<id> --volume $(pwd)/model_repository:/mnt/models:rw --publish 127.0.0.1::8998 --publish 127.0.0.1::50051 <image>
+        $ docker run -d --device /dev/dri --device /dev/xclmgmt<id> --volume $(pwd)/model_repository:/mnt/models:rw --publish 127.0.0.1::8998 --publish 127.0.0.1::50051 amdih/serve:uif1.1_vai_amdinfer_0.4.0
 
 The endpoints for each model will be the name of the model in the ``config.toml``, which should match the name of the parent directory in the model repository.
 In this example, it would be "resnet50".


### PR DESCRIPTION
# Summary of Changes

* Update favicons
* Change the image name for the main docs

# Motivation

The use of the older 0.3.0 image with the docs from HEAD leads to confusion as the old image doesn't work with the current state of the docs. Using an new image name makes it clearer that users will need to build an image themselves to use the main docs instead of the versioned one.

# Implementation

The favicon generation is from a website using the AMD logo. These are part of the theme and configured from `conf.py`.

The main version of the docs now uses the unreleased 0.4.0 version of the image that will be released next.

# Notes

To build the docs, you'll need to rebuild the dev container or install `sphinx-favicon` in your existing container.
