### PR TITLE
Add FP16 test in Python

### DIFF
--- a/examples/resnet50/migraphx.py
+++ b/examples/resnet50/migraphx.py
@@ -59,7 +59,7 @@ def preprocess(paths):
     options.convert_type = True
     options.type = cv2.CV_32FC3
     options.convert_scale = 1.0 / 255.0
-    return pre_post.imagePreprocessFloat(paths, options)
+    return pre_post.imagePreprocessFp32(paths, options)
 
 
 def postprocess(output, k):
@@ -74,7 +74,7 @@ def postprocess(output, k):
     Returns:
         list[int]: indices for the top k categories
     """
-    return pre_post.resnet50PostprocessFloat(output, k)
+    return pre_post.resnet50PostprocessFp32(output, k)
 
 
 def construct_requests(images):

--- a/examples/resnet50/ptzendnn.py
+++ b/examples/resnet50/ptzendnn.py
@@ -53,7 +53,7 @@ def preprocess(paths):
     options.convert_type = True
     options.type = cv2.CV_32FC3
     options.convert_scale = 1.0 / 255.0
-    return pre_post.imagePreprocessFloat(paths, options)
+    return pre_post.imagePreprocessFp32(paths, options)
 
 
 def postprocess(output, k):
@@ -68,7 +68,7 @@ def postprocess(output, k):
     Returns:
         list[int]: indices for the top k categories
     """
-    return pre_post.resnet50PostprocessFloat(output, k)
+    return pre_post.resnet50PostprocessFp32(output, k)
 
 
 def construct_requests(images):

--- a/examples/resnet50/tfzendnn.py
+++ b/examples/resnet50/tfzendnn.py
@@ -47,7 +47,7 @@ def preprocess(paths):
     options.convert_color = True
     options.color_code = cv2.COLOR_BGR2RGB
     options.assign = True
-    return pre_post.imagePreprocessFloat(paths, options)
+    return pre_post.imagePreprocessFp32(paths, options)
 
 
 def postprocess(output, k):
@@ -62,7 +62,7 @@ def postprocess(output, k):
     Returns:
         list[int]: indices for the top k categories
     """
-    return pre_post.resnet50PostprocessFloat(output, k)
+    return pre_post.resnet50PostprocessFp32(output, k)
 
 
 def construct_requests(images):

--- a/src/amdinfer/bindings/python/core/bind_fp16.hpp
+++ b/src/amdinfer/bindings/python/core/bind_fp16.hpp
@@ -41,6 +41,8 @@
 #include <pybind11/numpy.h>
 #include <pybind11/pybind11.h>
 
+#include "amdinfer/core/data_types.hpp"
+
 namespace pybind11::detail {
 
 template <typename T>

--- a/src/amdinfer/bindings/python/core/bind_fp16.hpp
+++ b/src/amdinfer/bindings/python/core/bind_fp16.hpp
@@ -1,0 +1,104 @@
+// Copyright 2017-2019 Eric Cousineau.
+// All rights reserved.
+
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+
+// Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimer.  Redistributions
+// in binary form must reproduce the above copyright notice, this list of
+// conditions and the following disclaimer in the documentation and/or
+// other materials provided with the distribution.  Neither the name of
+// the Massachusetts Institute of Technology nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+/**
+ * @file
+ * @brief Implements a binding and conversion between np.FLOAT16 and our fp16
+ * class. See
+ * https://github.com/eacousineau/repro/blob/e2792668a12b9cb8f79187a5853c6d5695e980a6/python/pybind11/custom_tests/test_numpy_issue1776.cc
+ */
+
+#ifndef GUARD_AMDINFER_BINDINGS_PYTHON_CORE_BIND_FP16
+#define GUARD_AMDINFER_BINDINGS_PYTHON_CORE_BIND_FP16
+
+#include <pybind11/embed.h>
+#include <pybind11/eval.h>
+#include <pybind11/numpy.h>
+#include <pybind11/pybind11.h>
+
+namespace pybind11::detail {
+
+template <typename T>
+struct npy_scalar_caster {
+  PYBIND11_TYPE_CASTER(T, _("PleaseOverride"));
+  using Array = array_t<T>;
+
+  bool load(handle src, bool convert) {
+    // Taken from Eigen casters. Permits either scalar dtype or scalar array.
+    handle type = dtype::of<T>().attr("type");  // Could make more efficient.
+    if (!convert && !isinstance<Array>(src) && !isinstance(src, type))
+      return false;
+    Array tmp = Array::ensure(src);
+    if (tmp && tmp.size() == 1 && tmp.ndim() == 0) {
+      this->value = *tmp.data();
+      return true;
+    }
+    return false;
+  }
+
+  static handle cast(T src, return_value_policy, handle) {
+    Array tmp({1});
+    tmp.mutable_at(0) = src;
+    tmp.resize({});
+    // You could also just return the array if you want a scalar array.
+    object scalar = tmp[tuple()];
+    return scalar.release();
+  }
+};
+
+// Similar to enums in `pybind11/numpy.h`. Determined by doing:
+// python3 -c 'import numpy as np; print(np.dtype(np.float16).num)'
+constexpr int NPY_FP16 = 23;
+
+// Kinda following:
+// https://github.com/pybind/pybind11/blob/9bb3313162c0b856125e481ceece9d8faa567716/include/pybind11/numpy.h#L1000
+template <>
+struct npy_format_descriptor<amdinfer::fp16> {
+  static pybind11::dtype dtype() {
+    handle ptr = npy_api::get().PyArray_DescrFromType_(NPY_FP16);
+    return reinterpret_borrow<pybind11::dtype>(ptr);
+  }
+  static std::string format() {
+    // following:
+    // https://docs.python.org/3/library/struct.html#format-characters
+    return "e";
+  }
+  // static constexpr auto name() {
+  //   return _("fp16");
+  // }
+  static constexpr auto name = _("float16");
+};
+
+template <>
+struct type_caster<amdinfer::fp16> : npy_scalar_caster<amdinfer::fp16> {
+  static constexpr auto name = _("float16");
+};
+
+}  // namespace pybind11::detail
+
+#endif  // GUARD_AMDINFER_BINDINGS_PYTHON_CORE_BIND_FP16

--- a/src/amdinfer/bindings/python/core/data_types.cpp
+++ b/src/amdinfer/bindings/python/core/data_types.cpp
@@ -58,6 +58,8 @@ void wrapDataType(py::module_& m) {
     .def_property_readonly_static(
       "FP16", [](const py::object& /*self*/) { return DataType("FP16"); })
     .def_property_readonly_static(
+      "FLOAT16", [](const py::object& /*self*/) { return DataType("FP16"); })
+    .def_property_readonly_static(
       "FP32", [](const py::object& /*self*/) { return DataType("FP32"); })
     .def_property_readonly_static(
       "FLOAT32", [](const py::object& /*self*/) { return DataType("FP32"); })

--- a/src/amdinfer/bindings/python/core/inference_request.cpp
+++ b/src/amdinfer/bindings/python/core/inference_request.cpp
@@ -30,6 +30,7 @@
 #include <sstream>        // IWYU pragma: keep
 #include <unordered_map>  // for unordered_map
 
+#include "amdinfer/bindings/python/core/bind_fp16.hpp"
 #include "amdinfer/bindings/python/helpers/docstrings.hpp"  // for DOCS
 #include "amdinfer/bindings/python/helpers/keep_alive.hpp"  // for keep_alive
 #include "amdinfer/bindings/python/helpers/print.hpp"       // for toString

--- a/src/amdinfer/bindings/python/pre_post/image_preprocess.cpp
+++ b/src/amdinfer/bindings/python/pre_post/image_preprocess.cpp
@@ -30,6 +30,7 @@
 #include <string>  // for string
 #include <vector>  // for vector
 
+#include "amdinfer/bindings/python/core/bind_fp16.hpp"
 #include "amdinfer/core/inference_request.hpp"
 #include "amdinfer/core/inference_response.hpp"
 #include "amdinfer/pre_post/resnet50_postprocess.hpp"  // for resnet50Postpr...
@@ -82,6 +83,13 @@ void wrapPrePost(py::module_& m) {
     ,
     py::arg("output"), py::arg("k"));
   m.def(
+    "resnet50PostprocessFp16",
+    [](const InferenceResponseOutput& output, int k) {
+      return pre_post::resnet50Postprocess<fp16>(
+        static_cast<fp16*>(output.getData()), output.getSize(), k);
+    },
+    py::arg("output"), py::arg("k"));
+  m.def(
     "resnet50PostprocessFloat",
     [](const InferenceResponseOutput& output, int k) {
       return pre_post::resnet50Postprocess<float>(
@@ -94,11 +102,14 @@ void wrapPrePost(py::module_& m) {
     .value("NCHW", pre_post::ImageOrder::NCHW);
 
   addPreprocessOptions<int8_t>(m, "ImagePreprocessOptionsInt8");
+  addPreprocessOptions<fp16>(m, "ImagePreprocessOptionsFp16");
   addPreprocessOptions<float>(m, "ImagePreprocessOptionsFloat");
 
   m.def("imagePreprocessInt8", &imagePreprocess<int8_t>, py::arg("paths"),
         py::arg("options"));
   m.def("imagePreprocessFloat", &imagePreprocess<float>, py::arg("paths"),
+        py::arg("options"));
+  m.def("imagePreprocessFp16", &imagePreprocess<fp16>, py::arg("paths"),
         py::arg("options"));
 }
 

--- a/src/amdinfer/bindings/python/pre_post/image_preprocess.cpp
+++ b/src/amdinfer/bindings/python/pre_post/image_preprocess.cpp
@@ -90,8 +90,19 @@ void wrapPrePost(py::module_& m) {
     },
     py::arg("output"), py::arg("k"));
   m.def(
+    "resnet50PostprocessFp32",
+    [](const InferenceResponseOutput& output, int k) {
+      return pre_post::resnet50Postprocess<float>(
+        static_cast<float*>(output.getData()), output.getSize(), k);
+    },
+    py::arg("output"), py::arg("k"));
+  m.def(
     "resnet50PostprocessFloat",
     [](const InferenceResponseOutput& output, int k) {
+      PyErr_WarnEx(PyExc_DeprecationWarning,
+                   "resnet50PostprocessFloat() is deprecated, use "
+                   "resnet50PostprocessFp32() instead",
+                   1);
       return pre_post::resnet50Postprocess<float>(
         static_cast<float*>(output.getData()), output.getSize(), k);
     },
@@ -107,7 +118,10 @@ void wrapPrePost(py::module_& m) {
 
   m.def("imagePreprocessInt8", &imagePreprocess<int8_t>, py::arg("paths"),
         py::arg("options"));
+  // deprecated
   m.def("imagePreprocessFloat", &imagePreprocess<float>, py::arg("paths"),
+        py::arg("options"));
+  m.def("imagePreprocessFp32", &imagePreprocess<float>, py::arg("paths"),
         py::arg("options"));
   m.def("imagePreprocessFp16", &imagePreprocess<fp16>, py::arg("paths"),
         py::arg("options"));

--- a/src/amdinfer/bindings/python/src/amdinfer/__init__.py
+++ b/src/amdinfer/bindings/python/src/amdinfer/__init__.py
@@ -52,6 +52,8 @@ def _set_data(input_n, image):
         input_n.setInt32Data(image)
     elif input_n.datatype == DataType.INT64:
         input_n.setInt64Data(image)
+    elif input_n.datatype == DataType.FP16:
+        input_n.setFp16Data(image)
     elif input_n.datatype == DataType.FP32:
         input_n.setFp32Data(image)
     elif input_n.datatype == DataType.FP64:

--- a/src/amdinfer/workers/migraphx.cpp
+++ b/src/amdinfer/workers/migraphx.cpp
@@ -496,6 +496,10 @@ BatchPtr MIGraphXWorker::doRun(Batch* batch, const MemoryPool* pool) {
     }
   }
 
+  if (new_batch == nullptr) {
+    return new_batch;
+  }
+
   new_batch->setBuffers(std::move(input_buffers), {});
 
   timer.add("batch_stop");

--- a/src/amdinfer/workers/worker.hpp
+++ b/src/amdinfer/workers/worker.hpp
@@ -209,8 +209,7 @@ class SingleThreadedWorker : public Worker {
 
       auto new_batch = this->doRun(batch.get(), pool);
 
-      if (next_ != nullptr) {
-        assert(new_batch != nullptr);
+      if (next_ != nullptr && new_batch != nullptr) {
         assert(new_batch->size() == batch_size);
 #ifdef AMDINFER_ENABLE_TRACING
         for (auto i = 0U; i < batch_size; ++i) {

--- a/tests/kserve/test_resnet.py
+++ b/tests/kserve/test_resnet.py
@@ -50,7 +50,7 @@ def make_request_migraphx():
     options.convert_type = True
     options.type = cv2.CV_32FC3
     options.convert_scale = 1.0 / 255.0
-    images = pre_post.imagePreprocessFloat([image_path], options)
+    images = pre_post.imagePreprocessFp32([image_path], options)
 
     assert len(images) == 1
 

--- a/tests/validation/resnet50.py
+++ b/tests/validation/resnet50.py
@@ -55,7 +55,7 @@ def preprocess(paths):
     options.convert_type = True
     options.type = cv2.CV_32FC3
     options.convert_scale = 1.0 / 255.0
-    return pre_post.imagePreprocessFloat(paths, options)
+    return pre_post.imagePreprocessFp32(paths, options)
 
 
 def main(args):

--- a/tests/workers/test_migraphx.py
+++ b/tests/workers/test_migraphx.py
@@ -49,7 +49,7 @@ def preprocess_fp32(paths):
     options.convert_type = True
     options.type = cv2.CV_32FC3
     options.convert_scale = 1.0 / 255.0
-    return pre_post.imagePreprocessFloat(paths, options)
+    return pre_post.imagePreprocessFp32(paths, options)
 
 
 def preprocess_fp16(paths):
@@ -139,7 +139,8 @@ class TestMigraphx:
             check_response(response, amdinfer.DataType.FP32)
             outputs = response.getOutputs()
             assert len(outputs) == 1
-            top_k_responses = pre_post.resnet50PostprocessFloat(outputs[0], 5)
+
+            top_k_responses = pre_post.resnet50PostprocessFp32(outputs[0], 5)
 
             assert top_k_responses == gold_responses[i % image_num]
 

--- a/tests/workers/test_ptzendnn.py
+++ b/tests/workers/test_ptzendnn.py
@@ -46,7 +46,7 @@ def preprocess(paths):
     options.convert_type = True
     options.type = cv2.CV_32FC3
     options.convert_scale = 1.0 / 255.0
-    return pre_post.imagePreprocessFloat(paths, options)
+    return pre_post.imagePreprocessFp32(paths, options)
 
 
 def postprocess(output, k):
@@ -61,7 +61,7 @@ def postprocess(output, k):
     Returns:
         list[int]: indices for the top k categories
     """
-    return pre_post.resnet50PostprocessFloat(output, k)
+    return pre_post.resnet50PostprocessFp32(output, k)
 
 
 @pytest.mark.extensions(["ptzendnn"])

--- a/tests/workers/test_tfzendnn.py
+++ b/tests/workers/test_tfzendnn.py
@@ -40,7 +40,7 @@ def preprocess(paths):
     options.convert_color = True
     options.color_code = cv2.COLOR_BGR2RGB
     options.assign = True
-    return pre_post.imagePreprocessFloat(paths, options)
+    return pre_post.imagePreprocessFp32(paths, options)
 
 
 def postprocess(output, k):
@@ -55,7 +55,7 @@ def postprocess(output, k):
     Returns:
         list[int]: indices for the top k categories
     """
-    return pre_post.resnet50PostprocessFloat(output, k)
+    return pre_post.resnet50PostprocessFp32(output, k)
 
 
 @pytest.mark.extensions(["tfzendnn"])


### PR DESCRIPTION
# Summary of Changes

* Add Python bindings for `fp16`
* Fix the return when migraphx worker throws an exception during the run

Closes #201

# Motivation

Sending float16 data to the server from Python is important to maintain parity with C++.

# Implementation

There was [an issue ](https://github.com/pybind/pybind11/issues/1776) raised in Pybind11 about this issue and a suggested workaround, which I've duplicated here.

Prior to this PR, the MIGraphX worker would crash the server if the worker threw an exception during batch processing. The cause was that that the `new_batch` was null. Now, this condition is checked for and it returns early. In the base class, I also allowed the return value from the worker to be null. This indicates that there is nothing to pass on to a subsequent worker even if one is configured. This scenario will occur in general when the worker encounters an error though the other workers aren't actively handling this well at the moment.

There are missing Python preprocessing methods for different types as they're being added on an as-needed basis. This also adds fp16 variants to them.

# Notes

The preprocessing code was using functions like `imagePreprocessFloat()` when FP32 was the only type bound. This function has been deprecated. Instead, new code should use `imagePreprocessFp32()`.
