### PR TITLE
Add a python test for vck5000

### DIFF
--- a/external/vcpkg/ports/rt-engine/fix-get_xclbins_in_dir.patch
+++ b/external/vcpkg/ports/rt-engine/fix-get_xclbins_in_dir.patch
@@ -1,0 +1,25 @@
+# Copyright 2023 Advanced Micro Devices, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+--- a/device/src/device_handle_xrm.cpp	2023-06-22 15:27:52.544963000 -0600
++++ b/device/src/device_handle_xrm.cpp	2023-06-22 15:28:11.340982000 -0600
+@@ -22,7 +22,7 @@
+
+   std::vector<std::string> xclbinPaths;
+
+-  for (const auto& file : fs::directory_iterator(path)) {
++  for (const auto& file : fs::recursive_directory_iterator(path)) {
+     auto fullPath = std::string(file.path());
+     if (fullPath.find(".xclbin") != std::string::npos)
+       xclbinPaths.push_back(fullPath);

--- a/external/vcpkg/ports/rt-engine/portfile.cmake
+++ b/external/vcpkg/ports/rt-engine/portfile.cmake
@@ -20,6 +20,7 @@ vcpkg_from_github(
   SHA512 9263ed06938fe7eae91cfc25fea0de28596b3f15b5eabe2c9095ee7046123916ca38b7c7c7962eaf58851b22c90d14f12965497bc7ded9ec623f3a584d3a2f00
   HEAD_REF master
   PATCHES fix-cmake.patch
+  PATCHES fix-get_xclbins_in_dir.patch
 )
 
 vcpkg_cmake_configure(

--- a/tests/download/models/resnet50.py
+++ b/tests/download/models/resnet50.py
@@ -25,7 +25,12 @@ def get(args: argparse.Namespace):
     if args.vitis:
         models["u250_resnet50"] = XModelOpenDownload(
             "resnet_v1_50_tf-u200-u250-r2.5.0.tar.gz",
-            directory,
+            directory / "u250",
+            "resnet_v1_50_tf/resnet_v1_50_tf.xmodel",
+        )
+        models["vck5000-4pe_resnet50"] = XModelOpenDownload(
+            "resnet_v1_50_tf-vck5000-DPUCVDX8H-4pe-r2.5.0.tar.gz",
+            directory / "vck5000",
             "resnet_v1_50_tf/resnet_v1_50_tf.xmodel",
         )
     if args.ptzendnn:

--- a/tests/workers/xmodel/test_resnet50.py
+++ b/tests/workers/xmodel/test_resnet50.py
@@ -34,10 +34,8 @@ def postprocess(output, k):
     return pre_post.resnet50PostprocessInt8(output, k)
 
 
-def validate(responses):
-    golden = [259, 261, 260, 157, 230]
+def validate(responses, golden):
     k = len(golden)
-
     for response in responses:
         assert not response.isError(), response.getError()
         assert response.id == ""
@@ -55,9 +53,9 @@ def validate(responses):
 @pytest.mark.extensions(["vitis"])
 @pytest.mark.fpgas("DPUCADF8H", 1)
 @pytest.mark.usefixtures("load")
-class TestXmodel:
+class TestXmodelU250:
     """
-    Test the Xmodel worker
+    Test the Xmodel worker on u250 board
     """
 
     @staticmethod
@@ -79,7 +77,8 @@ class TestXmodel:
             images, self.rest_client.modelMetadata(self.endpoint), True
         )
         response = self.rest_client.modelInfer(self.endpoint, request)
-        validate([response])
+        golden = [259, 261, 260, 157, 230]
+        validate([response], golden)
 
     @pytest.mark.benchmark(group="xmodel")
     def test_benchmark_xmodel(self, benchmark):
@@ -99,3 +98,33 @@ class TestXmodel:
         run_benchmark(
             benchmark, "xmodel", self.rest_client.modelInfer, request, **options
         )
+
+
+@pytest.mark.extensions(["vitis"])
+@pytest.mark.fpgas("DPUCVDX8H", 1)
+@pytest.mark.usefixtures("load")
+class TestXmodelVck50004pe:
+    """
+    Test the Xmodel worker on vck5000-4pe board
+    """
+
+    @staticmethod
+    def get_config():
+        model = "Xmodel"
+        parameters = amdinfer.ParameterMap(
+            ["model"], [amdinfer.testing.getPathToAsset("vck5000-4pe_resnet50")]
+        )
+        return (model, parameters)
+
+    def test_xmodel_0(self):
+        """
+        Send a request to resnet50 as tensor data
+        """
+        image_path = amdinfer.testing.getPathToAsset("asset_dog-3619020_640.jpg")
+        images = preprocess([image_path])
+        request = amdinfer.ImageInferenceRequest(
+            images, self.rest_client.modelMetadata(self.endpoint), True
+        )
+        response = self.rest_client.modelInfer(self.endpoint, request)
+        golden = [259, 261, 260, 157, 154]
+        validate([response], golden)


### PR DESCRIPTION
# Summary of Changes

Add a python test for running resnet50 on vck5000. 

# Motivation

We need a test for the vck5000 FPGA board.

# Implementation

Implementation is similar to that of the tests on u250 FPGA boards: pre-process the data and construct a request -> load the resnet50 model -> send the request to the server -> get the response and pro-process

# Notes

This PR requires existing users to redownload the test assets (resnet50 models for u250 and vck5000 boards) or this test will give an error about missing assets.


