### PR TITLE
Include tensor name in model metadata for xmodel worker

### DIFF
--- a/examples/resnet50/vitis.cpp
+++ b/examples/resnet50/vitis.cpp
@@ -41,10 +41,10 @@
 #include "amdinfer/amdinfer.hpp"
 // -include:
 
+#include "amdinfer/amdinfer.hpp"
 #include "amdinfer/pre_post/image_preprocess.hpp"
 #include "amdinfer/pre_post/resnet50_postprocess.hpp"
 #include "resnet50.hpp"
-#include "amdinfer/amdinfer.hpp"                    
 
 namespace fs = std::filesystem;
 
@@ -95,8 +95,9 @@ std::vector<int> postprocess(const amdinfer::InferenceResponseOutput& output,
  * @param input_size size of the square image in pixels
  * @return std::vector<amdinfer::InferenceRequest>
  */
-std::vector<amdinfer::InferenceRequest> constructRequests(const Images& images,
-                                                          int64_t input_size, const amdinfer::ModelMetadata& modelMetadata) {
+std::vector<amdinfer::InferenceRequest> constructRequests(
+  const Images& images, int64_t input_size,
+  const amdinfer::ModelMetadata& modelMetadata) {
   // +construct request:
   std::vector<amdinfer::InferenceRequest> requests;
   requests.reserve(images.size());
@@ -108,7 +109,8 @@ std::vector<amdinfer::InferenceRequest> constructRequests(const Images& images,
     requests.emplace_back();
     // NOLINTNEXTLINE(google-readability-casting)
     requests.back().addInputTensor((void*)image.data(), shape,
-                                   amdinfer::DataType::Int8, modelMetadata.getInputs()[i].getName());
+                                   amdinfer::DataType::Int8,
+                                   modelMetadata.getInputs()[i].getName());
   }
   // -construct request:
 
@@ -229,8 +231,8 @@ int main(int argc, char* argv[]) {
     Images images = preprocess(paths);
     // -prepare images:
 
-    std::vector<amdinfer::InferenceRequest> requests =
-      constructRequests(images, args.input_size, client.modelMetadata(endpoint));
+    std::vector<amdinfer::InferenceRequest> requests = constructRequests(
+      images, args.input_size, client.modelMetadata(endpoint));
 
     assert(paths.size() == requests.size());
     const auto num_requests = requests.size();

--- a/examples/resnet50/vitis.cpp
+++ b/examples/resnet50/vitis.cpp
@@ -44,6 +44,7 @@
 #include "amdinfer/pre_post/image_preprocess.hpp"
 #include "amdinfer/pre_post/resnet50_postprocess.hpp"
 #include "resnet50.hpp"
+#include "amdinfer/amdinfer.hpp"                    
 
 namespace fs = std::filesystem;
 
@@ -95,18 +96,19 @@ std::vector<int> postprocess(const amdinfer::InferenceResponseOutput& output,
  * @return std::vector<amdinfer::InferenceRequest>
  */
 std::vector<amdinfer::InferenceRequest> constructRequests(const Images& images,
-                                                          int64_t input_size) {
+                                                          int64_t input_size, const amdinfer::ModelMetadata& modelMetadata) {
   // +construct request:
   std::vector<amdinfer::InferenceRequest> requests;
   requests.reserve(images.size());
 
   const std::initializer_list<int64_t> shape = {input_size, input_size, 3};
 
-  for (const auto& image : images) {
+  for (unsigned i = 0; i < images.size(); i++) {
+    const auto& image = images[i];
     requests.emplace_back();
     // NOLINTNEXTLINE(google-readability-casting)
     requests.back().addInputTensor((void*)image.data(), shape,
-                                   amdinfer::DataType::Int8);
+                                   amdinfer::DataType::Int8, modelMetadata.getInputs()[i].getName());
   }
   // -construct request:
 
@@ -228,7 +230,7 @@ int main(int argc, char* argv[]) {
     // -prepare images:
 
     std::vector<amdinfer::InferenceRequest> requests =
-      constructRequests(images, args.input_size);
+      constructRequests(images, args.input_size, client.modelMetadata(endpoint));
 
     assert(paths.size() == requests.size());
     const auto num_requests = requests.size();

--- a/examples/resnet50/vitis.py
+++ b/examples/resnet50/vitis.py
@@ -68,20 +68,21 @@ def postprocess(output, k):
 
 
 # +construct request
-def construct_requests(images):
+def construct_requests(images, modelMetaData):
     """
     Construct requests for the inference server from the input images. For ResNet50,
     a valid request includes a single input tensor containing a square image.
 
     Args:
         images (list[numpy.ndarray]): the input images
+        modelMetaData(ModelMetadata): the model metadata
 
     Returns:
         list[amdinfer.InferenceRequest]: the requests
     """
     requests = []
     for image in images:
-        requests.append(amdinfer.ImageInferenceRequest(image))
+        requests.append(amdinfer.ImageInferenceRequest(image, modelMetaData))
     return requests
 
 
@@ -200,7 +201,7 @@ def main(args):
     images = preprocess(paths)
     # -prepare images
 
-    requests = construct_requests(images)
+    requests = construct_requests(images, client.modelMetadata(endpoint))
 
     assert len(paths) == len(requests)
     print("Making inferences...")

--- a/src/amdinfer/bindings/python/core/model_metadata.cpp
+++ b/src/amdinfer/bindings/python/core/model_metadata.cpp
@@ -58,6 +58,7 @@ void wrapModelMetadata(py::module_ &m) {
     .def_property("name", &ModelMetadata::getName, &ModelMetadata::setName)
     .def("getPlatform", &ModelMetadata::getPlatform,
          DOCS(ModelMetadata, getPlatform))
+    .def("getInputs", &ModelMetadata::getInputs, DOCS(ModelMetadata, getInputs))
     .def("setReady", &ModelMetadata::setReady, DOCS(ModelMetadata, setReady))
     .def("isReady", &ModelMetadata::isReady, DOCS(ModelMetadata, isReady));
 }

--- a/src/amdinfer/bindings/python/src/amdinfer/__init__.py
+++ b/src/amdinfer/bindings/python/src/amdinfer/__init__.py
@@ -77,7 +77,7 @@ def ImageInferenceRequest(images, modelMetaData=None, asTensor=True):
     Args:
         images (image): Images may be numpy arrays or filepaths or a list of these
         modelMetaData(ModelMetadata): Pass the model metadata. Defaults to None.
-        asTensor (bool, optional): Send data as a tensor or as base64-encoded string. Defaults to True. 
+        asTensor (bool, optional): Send data as a tensor or as base64-encoded string. Defaults to True.
 
     Raises:
         TypeError: Raised if an unknown image format is passed

--- a/src/amdinfer/bindings/python/src/amdinfer/__init__.py
+++ b/src/amdinfer/bindings/python/src/amdinfer/__init__.py
@@ -70,13 +70,14 @@ def stringToArray(data):
     return array.view(np.uint8)
 
 
-def ImageInferenceRequest(images, asTensor=True):
+def ImageInferenceRequest(images, modelMetaData=None, asTensor=True):
     """
     Construct a request from an image or list of images
 
     Args:
         images (image): Images may be numpy arrays or filepaths or a list of these
-        asTensor (bool, optional): Send data as a tensor or as base64-encoded string. Defaults to True.
+        modelMetaData(ModelMetadata): Pass the model metadata. Defaults to None.
+        asTensor (bool, optional): Send data as a tensor or as base64-encoded string. Defaults to True. 
 
     Raises:
         TypeError: Raised if an unknown image format is passed
@@ -94,7 +95,10 @@ def ImageInferenceRequest(images, asTensor=True):
     request = InferenceRequest()
     for index, image in enumerate(images):
         input_n = InferenceRequestInput()
-        input_n.name = f"input{index}"
+        if modelMetaData != None:
+            input_n.name = modelMetaData.getInputs()[index].name
+        else:
+            input_n.name = f"input{index}"
         if isinstance(image, str):
             if asTensor:
                 read_image = cv2.imread(image)

--- a/src/amdinfer/workers/xmodel.cpp
+++ b/src/amdinfer/workers/xmodel.cpp
@@ -296,7 +296,7 @@ BatchPtr XModel::doRun(Batch* batch, const MemoryPool* pool) {
   if (new_batch == nullptr) {
     return new_batch;
   }
-  
+
   new_batch->setBuffers(std::move(new_input_buffers), {});
 
   return new_batch;

--- a/src/amdinfer/workers/xmodel.cpp
+++ b/src/amdinfer/workers/xmodel.cpp
@@ -152,11 +152,13 @@ void XModel::doAcquire(ParameterMap* parameters) {
 
   runner_ = vart::Runner::create_runner(this->subgraph_, "run");
   auto input_tensors = runner_->get_input_tensors();
-  // assuming only one tensor as in doInit()
-  auto input_shape = input_tensors[0]->get_shape();
-  auto input_type = mapXirToType(input_tensors[0]->get_data_type());
-  this->batch_size_ = input_shape[0];
-  this->metadata_.addInputTensor("input", input_shape, input_type);
+  // populate the tensor metadata
+  for (const auto* tensor : input_tensors) {
+    auto input_shape = tensor->get_shape();
+    auto input_type = mapXirToType(tensor->get_data_type());
+    this->batch_size_ = input_shape[0];
+    this->metadata_.addInputTensor(tensor->get_name(), input_shape, input_type);
+  }
 
   auto output_tensors = runner_->get_output_tensors();
   for (const auto* tensor : output_tensors) {
@@ -166,7 +168,7 @@ void XModel::doAcquire(ParameterMap* parameters) {
     output_size_.emplace_back(
       util::containerProduct(output_shape.begin() + 1, output_shape.end()));
     // TODO(varunsh): what should we return here?
-    this->metadata_.addOutputTensor("output", output_shape,
+    this->metadata_.addOutputTensor(tensor->get_name(), output_shape,
                                     output_type_.back());
   }
 }
@@ -180,93 +182,121 @@ BatchPtr XModel::doRun(Batch* batch, const MemoryPool* pool) {
     logTraceBuffer(getLogger(), buffer->data(0));
   }
 #endif  // AMDINFER_ENABLE_LOGGING
-
-  std::vector<vart::TensorBuffer*> inputs_ptr;
-  for (const auto& buffer : input_buffers) {
-    auto* vart = dynamic_cast<VartTensorBuffer*>(buffer.get());
-    inputs_ptr.emplace_back(vart->getTensorBuffer());
-  }
-
+  BatchPtr new_batch = nullptr;
   BufferPtrs output_buffers;
   BufferPtrs new_input_buffers;
-  auto output_tensors = this->getRunner()->get_output_tensors();
-  for (const auto* tensor : output_tensors) {
-    auto xir_shape = tensor->get_shape();
-    std::vector<int64_t> shape{xir_shape.begin(), xir_shape.end()};
-    auto xir_type = tensor->get_data_type();
-    auto type = mapXirToType(xir_type);
-    InferenceRequestInput input(nullptr, shape, type, tensor->get_name());
-    // the shape includes the batch size so use external batch size 1
-    output_buffers.push_back(
-      pool->get({MemoryAllocators::VartTensor}, input, 1));
-    new_input_buffers.push_back(pool->get(next_allocators_, input, 1));
-  }
-
-  std::vector<vart::TensorBuffer*> outputs_ptr;
-  for (const auto& buffer : output_buffers) {
-    auto* vart = dynamic_cast<VartTensorBuffer*>(buffer.get());
-    outputs_ptr.emplace_back(vart->getTensorBuffer());
-  }
-
-  // auto outputs_ptr = this->getRunner()->get_outputs();
-
-  for (auto* input : inputs_ptr) {
-    const auto* tensor = input->get_tensor();
-    auto num = tensor->get_element_num();
-    auto batches = (tensor->get_shape())[0];
-    input->sync_for_write(0, num / batches);
-  }
-
-  std::queue<std::pair<uint32_t, int>> futures;
-  futures.push(getRunner()->execute_async(inputs_ptr, outputs_ptr));
-
-  while (!futures.empty()) {
-    auto job_id = futures.front();
-    futures.pop();
-    getRunner()->wait(job_id.first, -1);
-  }
-
-  for (auto* output : outputs_ptr) {
-    const auto* tensor = output->get_tensor();
-    output->sync_for_read(0,
-                          tensor->get_element_num() / (tensor->get_shape())[0]);
-  }
-
-  const auto num_batches = batch->size();
-  auto new_batch = batch->propagate();
-  for (unsigned int k = 0; k < num_batches; k++) {
-    const auto& req = batch->getRequest(k);
-
-    auto new_request = req->propagate();
-
-    const auto num_outputs = outputs_ptr.size();
-    for (unsigned int i = 0; i < num_outputs; i++) {
-      auto output_shape = output_tensors[i]->get_shape();
-      std::vector<int64_t> new_shape;
-      new_shape.reserve(output_shape.size() - 1);
-      for (auto j = 1U; j < output_shape.size(); j++) {
-        new_shape.push_back(output_shape[j]);
+  try {
+    std::vector<vart::TensorBuffer*> inputs_ptr;
+    for (unsigned i = 0; i < input_buffers.size(); i++) {
+      const auto& buffer = input_buffers[i];
+      auto* vart = dynamic_cast<VartTensorBuffer*>(buffer.get());
+      // Check if model tensor name equals input tensor name
+      const auto* runner_buffer = runner_->get_input_tensors()[i];
+      if (vart->getTensorBuffer()->get_tensor()->get_name() !=
+          runner_buffer->get_name()) {
+        throw std::runtime_error(
+          "input tensor name ('" +
+          vart->getTensorBuffer()->get_tensor()->get_name() +
+          "') does not equal model tensor name ('" + runner_buffer->get_name() +
+          "')!");
       }
-      auto* output_index =
-        reinterpret_cast<void*>(outputs_ptr.at(i)->data().first);
-
-      auto* data_ptr = new_input_buffers.at(i)->data(k * output_size_[i] *
-                                                     (output_type_[i]).size());
-      new_request->addInputTensor(
-        InferenceRequestInput{data_ptr, new_shape, output_type_[i], ""});
-      util::copy(
-        reinterpret_cast<int8_t*>(output_index) + (i * output_size_[i]),
-        static_cast<std::byte*>(data_ptr),
-        output_size_[i] * output_type_[i].size());
+      inputs_ptr.emplace_back(vart->getTensorBuffer());
     }
 
-    new_batch->addRequest(new_request);
+    auto output_tensors = this->getRunner()->get_output_tensors();
 
-    new_batch->setModel(k, "xmodel");
+    for (const auto* tensor : output_tensors) {
+      auto xir_shape = tensor->get_shape();
+      std::vector<int64_t> shape{xir_shape.begin(), xir_shape.end()};
+      auto xir_type = tensor->get_data_type();
+      auto type = mapXirToType(xir_type);
+      InferenceRequestInput input(nullptr, shape, type, tensor->get_name());
+      // the shape includes the batch size so use external batch size 1
+      output_buffers.push_back(
+        pool->get({MemoryAllocators::VartTensor}, input, 1));
+      new_input_buffers.push_back(pool->get(next_allocators_, input, 1));
+    }
+
+    std::vector<vart::TensorBuffer*> outputs_ptr;
+    for (const auto& buffer : output_buffers) {
+      auto* vart = dynamic_cast<VartTensorBuffer*>(buffer.get());
+      outputs_ptr.emplace_back(vart->getTensorBuffer());
+    }
+
+    // auto outputs_ptr = this->getRunner()->get_outputs();
+
+    for (auto* input : inputs_ptr) {
+      const auto* tensor = input->get_tensor();
+      auto num = tensor->get_element_num();
+      auto batches = (tensor->get_shape())[0];
+      input->sync_for_write(0, num / batches);
+    }
+
+    std::queue<std::pair<uint32_t, int>> futures;
+    futures.push(getRunner()->execute_async(inputs_ptr, outputs_ptr));
+
+    while (!futures.empty()) {
+      auto job_id = futures.front();
+      futures.pop();
+      getRunner()->wait(job_id.first, -1);
+    }
+
+    for (auto* output : outputs_ptr) {
+      const auto* tensor = output->get_tensor();
+      output->sync_for_read(
+        0, tensor->get_element_num() / (tensor->get_shape())[0]);
+    }
+
+    const auto num_batches = batch->size();
+    new_batch = batch->propagate();
+    for (unsigned int k = 0; k < num_batches; k++) {
+      const auto& req = batch->getRequest(k);
+
+      auto new_request = req->propagate();
+
+      const auto num_outputs = outputs_ptr.size();
+      for (unsigned int i = 0; i < num_outputs; i++) {
+        auto output_shape = output_tensors[i]->get_shape();
+        std::vector<int64_t> new_shape;
+        new_shape.reserve(output_shape.size() - 1);
+        for (auto j = 1U; j < output_shape.size(); j++) {
+          new_shape.push_back(output_shape[j]);
+        }
+        auto* output_index =
+          reinterpret_cast<void*>(outputs_ptr.at(i)->data().first);
+
+        auto* data_ptr = new_input_buffers.at(i)->data(
+          k * output_size_[i] * (output_type_[i]).size());
+        new_request->addInputTensor(
+          InferenceRequestInput{data_ptr, new_shape, output_type_[i], ""});
+        util::copy(
+          reinterpret_cast<int8_t*>(output_index) + (i * output_size_[i]),
+          static_cast<std::byte*>(data_ptr),
+          output_size_[i] * output_type_[i].size());
+      }
+
+      new_batch->addRequest(new_request);
+
+      new_batch->setModel(k, "xmodel");
+    }
+    for (const auto& buffer : output_buffers) {
+      buffer->free();
+    }
+  } catch (const std::exception& e) {
+    // This outer catch block catches exceptions in evaluation of the batch.
+    AMDINFER_LOG_ERROR(getLogger(), e.what());
+    // Pass error message back as reply for each request in the batch
+    const auto& requests = batch->getRequests();
+    for (const auto& req_e : requests) {
+      req_e->runCallbackError(std::string("Xmodel inference error: ") +
+                              e.what());
+    }
   }
-  for (const auto& buffer : output_buffers) {
-    buffer->free();
+
+  if (new_batch == nullptr) {
+    return new_batch;
   }
+  
   new_batch->setBuffers(std::move(new_input_buffers), {});
 
   return new_batch;

--- a/tests/workers/test_facedetect.py
+++ b/tests/workers/test_facedetect.py
@@ -102,7 +102,8 @@ class TestInferImageFacedetectDPUCADF8H:
         image_path = amdinfer.testing.getPathToAsset("asset_girl-1867092_640.jpg")
         batch = 1
         images = [image_path] * batch
-        request = amdinfer.ImageInferenceRequest(images, asTensor)
+        modelMetadata = None
+        request = amdinfer.ImageInferenceRequest(images, modelMetadata, asTensor)
 
         return request
 

--- a/tests/workers/test_invert_image.py
+++ b/tests/workers/test_invert_image.py
@@ -52,8 +52,8 @@ def compare_jpgs(test_image, reference_image):
 
 def construct_request(asTensor):
     image_path = amdinfer.testing.getPathToAsset("asset_dog-3619020_640.jpg")
-
-    request = amdinfer.ImageInferenceRequest(image_path, asTensor)
+    modelMetadata = None
+    request = amdinfer.ImageInferenceRequest(image_path, modelMetadata, asTensor)
 
     image = cv2.imread(image_path)
     image = cv2.bitwise_not(image)

--- a/tests/workers/test_migraphx.py
+++ b/tests/workers/test_migraphx.py
@@ -128,8 +128,8 @@ class TestMigraphx:
         request_num = num
         for i in range(request_num):
             img = preprocess_fp32([image_paths[i % image_num]])[0]
-
-            request = amdinfer.ImageInferenceRequest(img, True)
+            modelMetadata = None
+            request = amdinfer.ImageInferenceRequest(img, modelMetadata, True)
             try:
                 response = self.rest_client.modelInfer(self.endpoint, request)
             except ConnectionError:
@@ -176,7 +176,7 @@ class TestMigraphxFp16:
         for i in range(request_num):
             img = preprocess_fp16([image_paths[i % image_num]])[0]
 
-            request = amdinfer.ImageInferenceRequest(img, True)
+            request = amdinfer.ImageInferenceRequest(img, None, True)
             try:
                 response = self.rest_client.modelInfer(self.endpoint, request)
             except ConnectionError:
@@ -209,7 +209,7 @@ class TestMigraphxFp16:
         for i in range(request_num):
             img = preprocess_fp32([image_paths[i % image_num]])[0]
 
-            request = amdinfer.ImageInferenceRequest(img, True)
+            request = amdinfer.ImageInferenceRequest(img, None, True)
             with pytest.raises(
                 amdinfer.BadStatus,
                 match='{"error":"Migraphx inference error: Migraph worker model and input data types don\'t match:   FP16 vs FP32"}',

--- a/tests/workers/test_migraphx.py
+++ b/tests/workers/test_migraphx.py
@@ -175,8 +175,8 @@ class TestMigraphxFp16:
         request_num = num
         for i in range(request_num):
             img = preprocess_fp16([image_paths[i % image_num]])[0]
-
-            request = amdinfer.ImageInferenceRequest(img, None, True)
+            modelMetadata = None
+            request = amdinfer.ImageInferenceRequest(img, modelMetadata, True)
             try:
                 response = self.rest_client.modelInfer(self.endpoint, request)
             except ConnectionError:
@@ -208,8 +208,8 @@ class TestMigraphxFp16:
         request_num = num
         for i in range(request_num):
             img = preprocess_fp32([image_paths[i % image_num]])[0]
-
-            request = amdinfer.ImageInferenceRequest(img, None, True)
+            modelMetadata = None
+            request = amdinfer.ImageInferenceRequest(img, modelMetadata, True)
             with pytest.raises(
                 amdinfer.BadStatus,
                 match='{"error":"Migraphx inference error: Migraph worker model and input data types don\'t match:   FP16 vs FP32"}',

--- a/tests/workers/test_ptzendnn.py
+++ b/tests/workers/test_ptzendnn.py
@@ -126,7 +126,8 @@ class TestPtZendnn:
         image_paths = [image_path] * batch
         images = preprocess(image_paths)
         for image in images:
-            request = amdinfer.ImageInferenceRequest(image, True)
+            modelMetadata = None
+            request = amdinfer.ImageInferenceRequest(image, modelMetadata, True)
             response = self.send_request(request)
             outputs = response.getOutputs()
             top_k_responses = postprocess(outputs[0], 5)

--- a/tests/workers/test_resnet50_dpucadf8h.py
+++ b/tests/workers/test_resnet50_dpucadf8h.py
@@ -27,8 +27,8 @@ def construct_request(asTensor, batches=1):
 
     # TODO(vishalk): AKS gives a segfault if batch != 4
     images = [image_path] * batches
-
-    return amdinfer.ImageInferenceRequest(images, asTensor)
+    modelMetadata = None
+    return amdinfer.ImageInferenceRequest(images, modelMetadata, asTensor)
 
 
 @pytest.mark.extensions(["aks", "vitis"])

--- a/tests/workers/test_tfzendnn.py
+++ b/tests/workers/test_tfzendnn.py
@@ -124,7 +124,8 @@ class TestTfZendnn:
         image_paths = [image_path] * batch
         images = preprocess(image_paths)
         for image in images:
-            request = amdinfer.ImageInferenceRequest(image, True)
+            modelMetadata = None
+            request = amdinfer.ImageInferenceRequest(image, modelMetadata, True)
             response = self.send_request(request)
             outputs = response.getOutputs()
             top_k_responses = postprocess(outputs[0], 5)

--- a/tests/workers/test_yolov3.py
+++ b/tests/workers/test_yolov3.py
@@ -105,7 +105,8 @@ class TestInferImageYoloV3DPUCADF8H:
 
         batch = 1
         images = [image_path] * batch
-        request = amdinfer.ImageInferenceRequest(images, asTensor)
+        modelMetadata = None
+        request = amdinfer.ImageInferenceRequest(images, modelMetadata, asTensor)
 
         return request
 

--- a/tests/workers/xmodel/test_resnet50.cpp
+++ b/tests/workers/xmodel/test_resnet50.cpp
@@ -53,16 +53,19 @@ std::string workerLoad(Client* client, const ParameterMap& parameters) {
   return client->workerLoad("Xmodel", parameters);
 }
 
-std::vector<InferenceRequest> constructRequests(const Images& images) {
+std::vector<InferenceRequest> constructRequests(
+  const Images& images, const ModelMetadata& modelMetadata) {
   std::vector<InferenceRequest> requests;
   requests.reserve(images.size());
 
   const std::initializer_list<int64_t> shape = {224, 224, 3};
 
-  for (const auto& image : images) {
+  for (unsigned i = 0; i < images.size(); i++) {
+    const auto& image = images[i];
     requests.emplace_back();
     // NOLINTNEXTLINE(google-readability-casting)
-    requests.back().addInputTensor((void*)image.data(), shape, DataType::Int8);
+    requests.back().addInputTensor((void*)image.data(), shape, DataType::Int8,
+                                   modelMetadata.getInputs()[i].getName());
   }
 
   return requests;
@@ -99,7 +102,8 @@ void test0(Client* client) {
 
   auto images = preprocess({test_asset});
   auto endpoint = workerLoad(client, parameters);
-  auto requests = constructRequests(images);
+  auto modelMetadata = client->modelMetadata(endpoint);
+  auto requests = constructRequests(images, modelMetadata);
   auto responses = inferAsyncOrdered(client, endpoint, requests);
   validate(responses);
 }

--- a/tests/workers/xmodel/test_resnet50.py
+++ b/tests/workers/xmodel/test_resnet50.py
@@ -75,7 +75,9 @@ class TestXmodel:
         image_path = amdinfer.testing.getPathToAsset("asset_dog-3619020_640.jpg")
 
         images = preprocess([image_path])
-        request = amdinfer.ImageInferenceRequest(images, True)
+        request = amdinfer.ImageInferenceRequest(
+            images, self.rest_client.modelMetadata(self.endpoint), True
+        )
         response = self.rest_client.modelInfer(self.endpoint, request)
         validate([response])
 
@@ -84,7 +86,9 @@ class TestXmodel:
         image_path = amdinfer.testing.getPathToAsset("asset_dog-3619020_640.jpg")
 
         images = preprocess([image_path])
-        request = amdinfer.ImageInferenceRequest(images, True)
+        request = amdinfer.ImageInferenceRequest(
+            images,  self.rest_client.modelMetadata(self.endpoint), True
+        )
 
         options = {
             "model": self.model,

--- a/tests/workers/xmodel/test_resnet50.py
+++ b/tests/workers/xmodel/test_resnet50.py
@@ -87,7 +87,7 @@ class TestXmodel:
 
         images = preprocess([image_path])
         request = amdinfer.ImageInferenceRequest(
-            images,  self.rest_client.modelMetadata(self.endpoint), True
+            images, self.rest_client.modelMetadata(self.endpoint), True
         )
 
         options = {


### PR DESCRIPTION
# Summary of Changes

Add tensor name to the model metadata such that when creating a request, we can ensure the input tensors have the same name as of the model tensors.

This is to fix the problem that test on vck5000 can not be run due to tensor name mismatches. Now we can query the model metadata and give the input tensors correct and expected names.

Closes https://github.com/Xilinx/inference-server/issues/204

# Motivation

We need add populate the model tensor name into the metadata such that users can query for that.

# Implementation

Modified xmodel backend source code to include this metadata. 

# Notes

All xmodel tests in the future can now query the modelmetadata to get the tensor names.
The metadata in  amdinfer.ImageInferenceRequest() will be required in the future.
