### PR TITLE
Fix quickstart script for 0.3.0

### DIFF
--- a/examples/resnet50/quickstart-setup.sh
+++ b/examples/resnet50/quickstart-setup.sh
@@ -22,25 +22,30 @@ wget -O tensorflow.zip https://www.xilinx.com/bin/public/openDownload?filename=t
 unzip -j "tensorflow.zip" "tf_resnetv1_50_imagenet_224_224_6.97G_2.5/float/resnet_v1_50_baseline_6.96B_922.pb" -d .
 mkdir -p model_repository/resnet50/1
 mv ./resnet_v1_50_baseline_6.96B_922.pb model_repository/resnet50/1/saved_model.pb
-cat << EOF > model_repository/resnet50/config.toml
-name = "resnet50"
-platform = "tensorflow_graphdef"
-
-[[inputs]]
-name = "input"
-datatype = "FP32"
-shape = [224, 224, 3]
-
-[[outputs]]
-name = "resnet_v1_50/predictions/Reshape_1"
-datatype = "FP32"
-shape = [1000]
+cat << EOF > model_repository/resnet50/config.pbtxt
+name: "resnet50"
+platform: "tensorflow_graphdef"
+inputs [
+    {
+        name: "input"
+        datatype: "FP32"
+        shape: [224,224,3]
+    }
+]
+outputs [
+    {
+        name: "resnet_v1_50/predictions/Reshape_1"
+        datatype: "FP32"
+        shape: [1000]
+    }
+]
 EOF
 
+version="v0.3.0"
 # Download the class labels for this model
-wget https://github.com/Xilinx/inference-server/raw/main/examples/resnet50/imagenet_classes.txt
+wget https://github.com/Xilinx/inference-server/raw/${version}/examples/resnet50/imagenet_classes.txt
 # Download a sample image
-wget https://github.com/Xilinx/inference-server/raw/main/tests/assets/dog-3619020_640.jpg
+wget https://github.com/Xilinx/inference-server/raw/${version}/tests/assets/dog-3619020_640.jpg
 # Download the example Python code
-wget https://github.com/Xilinx/inference-server/raw/main/examples/resnet50/resnet.py
-wget https://github.com/Xilinx/inference-server/raw/main/examples/resnet50/tfzendnn.py
+wget https://github.com/Xilinx/inference-server/raw/${version}/examples/resnet50/resnet.py
+wget https://github.com/Xilinx/inference-server/raw/${version}/examples/resnet50/tfzendnn.py


### PR DESCRIPTION
# Summary of Changes

* Fix the quickstart script in the README

Closes #209

# Motivation

The quickstart instructions should work.

# Implementation

The script now uses the last publicly released 0.3.0 version to get files and configure the repository. Previously, it was a non-working combination of 0.3.0 and the main version.

# Notes

N/A
