### PR TITLE
Add resize to Python preprocess binding

### DIFF
--- a/docs/backends/migraphx.rst
+++ b/docs/backends/migraphx.rst
@@ -52,7 +52,7 @@ Other devices and DPUs may also work but are currently untested.
 Host setup
 ----------
 
-Follow the `ROCm installation instructions <https://docs.amd.com/category/Release%20Documentation>`__ to install ROCm on your host machine.
+Follow the `ROCm installation instructions <https://docs.amd.com/en/latest/deploy/linux/index.html`__ to install ROCm on your host machine.
 Your ROCm version should ideally match the version installed in the inference server container but mismatching versions may work as well in some cases.
 Ensure you can detect the GPUs on your host machine with ``/opt/rocm/bin/rocminfo``.
 

--- a/docs/backends/ptzendnn.rst
+++ b/docs/backends/ptzendnn.rst
@@ -42,7 +42,7 @@ Build an image
 
 To build an image with the PtZenDNN backend enabled, you need to download the ZenDNN library and then build the image by pointing the build script to the location of this downloaded package.
 
-You can download the PT+ZenDNN package from the `ZenDNN developer downloads <ZenDNN_download>`_: ``PT_v1.12_ZenDNN_v4.0_C++_API.zip``.
+You can download the PT+ZenDNN package from the `ZenDNN developer downloads <LinkZenDNNdownload_>`_: ``PT_v1.12_ZenDNN_v4.0_C++_API.zip``.
 Before downloading this packages, you will be required to read and agree to the :term:`EULA`.
 
 After downloading the package, place it in the root of the repository.

--- a/docs/backends/tfzendnn.rst
+++ b/docs/backends/tfzendnn.rst
@@ -40,7 +40,7 @@ Build an image
 
 To build an image with the TfZenDNN backend enabled, you need to download the ZenDNN library and then build the image by pointing the build script to the location of this downloaded package.
 
-You can download the PT+ZenDNN package from the `ZenDNN developer downloads <ZenDNN_download>`_: ``TF_v2.10_ZenDNN_v4.0_C++_API.zip``.
+You can download the PT+ZenDNN package from the `ZenDNN developer downloads <LinkZenDNNdownload_>`_: ``TF_v2.10_ZenDNN_v4.0_C++_API.zip``.
 Before downloading this packages, you will be required to read and agree to the :term:`EULA`.
 
 After downloading the package, place it in the root of the repository.

--- a/docs/backends/vitis_ai.rst
+++ b/docs/backends/vitis_ai.rst
@@ -50,7 +50,7 @@ Other devices and DPUs may also work but are currently untested.
 Host setup
 ----------
 
-The details for setting up your host are available online in the :vitisAItree:`Vitis AI <setup>` repository.
+The details for setting up your host are available online in the :vitisAItree:`Vitis AI <board_setup>` repository.
 These instructions will depend on the FPGAs you are targeting.
 In essence, you will need to install software, program the shell on the FPGA(s) and download its ``xclbin`` files.
 

--- a/examples/resnet50/migraphx.py
+++ b/examples/resnet50/migraphx.py
@@ -33,7 +33,7 @@ import amdinfer.pre_post as pre_post
 from resnet import parse_args, print_label, resolve_image_paths
 
 
-def preprocess(paths):
+def preprocess(paths, input_size):
     """
     Given a list of paths to images, preprocess the images and return them
 
@@ -59,6 +59,9 @@ def preprocess(paths):
     options.convert_type = True
     options.type = cv2.CV_32FC3
     options.convert_scale = 1.0 / 255.0
+    options.resize = True
+    options.height = input_size
+    options.width = input_size
     return pre_post.imagePreprocessFp32(paths, options)
 
 
@@ -200,7 +203,7 @@ def main(args):
 
     paths = resolve_image_paths(pathlib.Path(args.image))
 
-    images = preprocess(paths)
+    images = preprocess(paths, args.input_size)
 
     requests = construct_requests(images)
 

--- a/examples/resnet50/ptzendnn.py
+++ b/examples/resnet50/ptzendnn.py
@@ -33,7 +33,7 @@ import amdinfer.pre_post as pre_post
 from resnet import parse_args, print_label, resolve_image_paths
 
 
-def preprocess(paths):
+def preprocess(paths, input_size):
     """
     Given a list of paths to images, preprocess the images and return them
 
@@ -53,6 +53,9 @@ def preprocess(paths):
     options.convert_type = True
     options.type = cv2.CV_32FC3
     options.convert_scale = 1.0 / 255.0
+    options.resize = True
+    options.height = input_size
+    options.width = input_size
     return pre_post.imagePreprocessFp32(paths, options)
 
 
@@ -163,7 +166,7 @@ def main(args):
 
     paths = resolve_image_paths(pathlib.Path(args.image))
 
-    images = preprocess(paths)
+    images = preprocess(paths, args.input_size)
 
     requests = construct_requests(images)
 

--- a/examples/resnet50/tfzendnn.py
+++ b/examples/resnet50/tfzendnn.py
@@ -33,7 +33,7 @@ import amdinfer.pre_post as pre_post
 from resnet import parse_args, print_label, resolve_image_paths
 
 
-def preprocess(paths):
+def preprocess(paths, input_size):
     """
     Given a list of paths to images, preprocess the images and return them
 
@@ -47,6 +47,9 @@ def preprocess(paths):
     options.convert_color = True
     options.color_code = cv2.COLOR_BGR2RGB
     options.assign = True
+    options.resize = True
+    options.height = input_size
+    options.width = input_size
     return pre_post.imagePreprocessFp32(paths, options)
 
 
@@ -192,7 +195,7 @@ def main(args):
 
     paths = resolve_image_paths(pathlib.Path(args.image))
 
-    images = preprocess(paths)
+    images = preprocess(paths, args.input_size)
 
     requests = construct_requests(images)
 

--- a/examples/resnet50/vitis.py
+++ b/examples/resnet50/vitis.py
@@ -34,7 +34,7 @@ import amdinfer.pre_post as pre_post
 from resnet import parse_args, print_label, resolve_image_paths
 
 
-def preprocess(paths):
+def preprocess(paths, input_size):
     """
     Given a list of paths to images, preprocess the images and return them
 
@@ -49,6 +49,9 @@ def preprocess(paths):
     options.mean = [123, 107, 104]
     options.std = [1, 1, 1]
     options.normalize = True
+    options.resize = True
+    options.height = input_size
+    options.width = input_size
     return pre_post.imagePreprocessInt8(paths, options)
 
 
@@ -198,7 +201,7 @@ def main(args):
 
     # +prepare images
     paths = resolve_image_paths(pathlib.Path(args.image))
-    images = preprocess(paths)
+    images = preprocess(paths, args.input_size)
     # -prepare images
 
     requests = construct_requests(images, client.modelMetadata(endpoint))

--- a/src/amdinfer/bindings/python/pre_post/image_preprocess.cpp
+++ b/src/amdinfer/bindings/python/pre_post/image_preprocess.cpp
@@ -61,6 +61,7 @@ void addPreprocessOptions(const py::module& m, const char* name) {
     .def_readwrite("normalize", &ImagePreprocessOptions<T>::normalize)
     .def_readwrite("order", &ImagePreprocessOptions<T>::order)
     .def_readwrite("mean", &ImagePreprocessOptions<T>::mean)
+    .def_readwrite("resize", &ImagePreprocessOptions<T>::resize)
     .def_readwrite("std", &ImagePreprocessOptions<T>::std);
 }
 

--- a/tests/workers/test_migraphx.py
+++ b/tests/workers/test_migraphx.py
@@ -160,7 +160,7 @@ class TestMigraphxFp16:
         )
         return (model, parameters)
 
-    @pytest.mark.parametrize("num", [1])
+    @pytest.mark.parametrize("num", [1, 4])
     def test_migraphx_fp16(self, num):
         """
         Send a request to model as tensor data


### PR DESCRIPTION
# Summary of Changes

* Add image resizing to the Python preprocessing bindings
* Update doc links

# Motivation

The example scripts are being used by QA for running tests and the missing resize argument to the options prevents them from reusing these scripts for running similar models with different input sizes.

# Implementation

The resize option exists in C++ but was missing in Python.

There were also some broken links in the documentation that I fixed.

# Notes

N/A
