### PR TITLE
Add roctracer to migraphx package list

### DIFF
--- a/docker/generate.py
+++ b/docker/generate.py
@@ -606,6 +606,8 @@ def install_migraphx(manager: PackageManager, custom_backends):
                 # before installing migraphx
                 miopen-hip-dev \\
                 rocm-device-libs \\
+                # a runtime requirement for miopen that isn't automatically included
+                roctracer \\
                 rocblas-dev \\
                 libnuma1 \\
                 migraphx-dev \\


### PR DESCRIPTION
This is a workaround for a runtime requirement for miopen that is not automatically included as a MIOpen dependency

# Summary of Changes

* Adds the roctracer library to the script that creates the docker file.

Closes[ #SWDEV-429494](https://ontrack-internal.amd.com/browse/SWDEV-429494)

# Motivation

This library was added as a dependency to miopen in a change commit a few months ago.  It is not needed for the inference server except to suppress an error message at runtime.