### PR TITLE
Update ONNX download links

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -148,7 +148,7 @@ tree_path = f"https://github.com/Xilinx/inference-server/tree/{release}/%s"
 blob_path = f"https://github.com/Xilinx/inference-server/blob/{release}/%s"
 raw_path = f"https://github.com/Xilinx/inference-server/raw/{release}/%s"
 xilinx_download = "https://www.xilinx.com/bin/public/openDownload?filename=%s"
-github_onnx = "https://github.com/onnx/models/raw/main/%s"
+github_onnx = "https://github.com/onnx/models/raw/5faef4c33eba0395177850e1e31c4a6a9e634c82/%s"
 vitis_ai_path = "https://github.com/Xilinx/Vitis-AI/tree/v3.0/%s"
 
 # sphinx.ext.extlinks configuration. syntax is key: (url, caption). The key should not have underscores.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -148,7 +148,9 @@ tree_path = f"https://github.com/Xilinx/inference-server/tree/{release}/%s"
 blob_path = f"https://github.com/Xilinx/inference-server/blob/{release}/%s"
 raw_path = f"https://github.com/Xilinx/inference-server/raw/{release}/%s"
 xilinx_download = "https://www.xilinx.com/bin/public/openDownload?filename=%s"
-github_onnx = "https://github.com/onnx/models/raw/5faef4c33eba0395177850e1e31c4a6a9e634c82/%s"
+github_onnx = (
+    "https://github.com/onnx/models/raw/5faef4c33eba0395177850e1e31c4a6a9e634c82/%s"
+)
 vitis_ai_path = "https://github.com/Xilinx/Vitis-AI/tree/v3.0/%s"
 
 # sphinx.ext.extlinks configuration. syntax is key: (url, caption). The key should not have underscores.

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -75,7 +75,7 @@ The CPU version has no special hardware requirements to run so you can always ru
 
     .. code-tab:: console GPU
 
-        $ wget https://github.com/onnx/models/raw/main/vision/classification/resnet/model/resnet50-v2-7.onnx
+        $ wget https://github.com/onnx/models/raw/5faef4c33eba0395177850e1e31c4a6a9e634c82/vision/classification/resnet/model/resnet50-v2-7.onnx
         $ mkdir -p ./model_repository/resnet50/1
         $ mv ./resnet50-v2-7.onnx ./model_repository/resnet50/1/
 

--- a/examples/yolo/README.rst
+++ b/examples/yolo/README.rst
@@ -31,7 +31,7 @@ The output shapes are: (1, 52, 52, 3, 85) (1, 26, 26, 3, 85) (1, 13, 13, 3, 85).
 There are 3 output layers. For each layer, there are 255 outputs: 85 values per anchor, times 3 anchors.
 The 85 values of each anchor consists of 4 box coordinates describing the predicted bounding box (x, y, h, w), 1 object confidence, and 80 class confidences.
 
-For more information about this model, look at the `ONNX model <https://github.com/onnx/models/tree/main/vision/object_detection_segmentation/yolov4>`__ online.
+For more information about this model, look at the `ONNX model <https://github.com/onnx/models/tree/5faef4c33eba0395177850e1e31c4a6a9e634c82/vision/object_detection_segmentation/yolov4>`__ online.
 
 Files
 ^^^^^

--- a/examples/yolo/yolo_image_processing.py
+++ b/examples/yolo/yolo_image_processing.py
@@ -21,8 +21,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 #####################################################################################
-# All pre- and post-processing methods used below are borrowed from the ONNX MOdel Zoo
-# https://github.com/onnx/models/tree/master/vision/object_detection_segmentation/yolov4
+# All pre- and post-processing methods used below are borrowed from the ONNX Model Zoo
+# https://github.com/onnx/models/tree/5faef4c33eba0395177850e1e31c4a6a9e634c82/vision/object_detection_segmentation/yolov4
 
 """
 Custom pre-and post-processing of images for running Yolo object detection models.

--- a/tests/download/models/bert.py
+++ b/tests/download/models/bert.py
@@ -24,7 +24,7 @@ def get(args: argparse.Namespace):
     models = {}
     if args.migraphx:
         models["onnx_bert"] = File(
-            "https://github.com/onnx/models/raw/main/text/machine_comprehension/bert-squad/model/bertsquad-10.onnx",
+            "https://github.com/onnx/models/raw/5faef4c33eba0395177850e1e31c4a6a9e634c82/text/machine_comprehension/bert-squad/model/bertsquad-10.onnx",
             directory,
             "",
         )

--- a/tests/download/models/resnet50.py
+++ b/tests/download/models/resnet50.py
@@ -47,7 +47,7 @@ def get(args: argparse.Namespace):
         )
     if args.migraphx:
         models["onnx_resnet50"] = File(
-            "https://github.com/onnx/models/raw/main/vision/classification/resnet/model/resnet50-v2-7.onnx",
+            "https://github.com/onnx/models/raw/5faef4c33eba0395177850e1e31c4a6a9e634c82/vision/classification/resnet/model/resnet50-v2-7.onnx",
             directory,
             "",
         )

--- a/tests/download/models/yolov4.py
+++ b/tests/download/models/yolov4.py
@@ -24,17 +24,17 @@ def get(args: argparse.Namespace):
     models = {}
     if args.migraphx:
         models["onnx_yolov4_anchors"] = File(
-            "https://github.com/onnx/models/raw/main/vision/object_detection_segmentation/yolov4/dependencies/yolov4_anchors.txt",
+            "https://github.com/onnx/models/raw/5faef4c33eba0395177850e1e31c4a6a9e634c82/vision/object_detection_segmentation/yolov4/dependencies/yolov4_anchors.txt",
             directory,
             "",
         )
         models["onnx_yolov4"] = File(
-            "https://github.com/onnx/models/raw/main/vision/object_detection_segmentation/yolov4/model/yolov4.onnx",
+            "https://github.com/onnx/models/raw/5faef4c33eba0395177850e1e31c4a6a9e634c82/vision/object_detection_segmentation/yolov4/model/yolov4.onnx",
             directory,
             "",
         )
         models["onnx_yolov4_coco"] = File(
-            "https://github.com/onnx/models/raw/main/vision/object_detection_segmentation/yolov4/dependencies/coco.names",
+            "https://github.com/onnx/models/raw/5faef4c33eba0395177850e1e31c4a6a9e634c82/vision/object_detection_segmentation/yolov4/dependencies/coco.names",
             directory,
             "",
         )

--- a/tests/validation/resnet50.py
+++ b/tests/validation/resnet50.py
@@ -21,8 +21,8 @@ The model file and test data is not in the git repo. and must be fetched with gi
     amdinfer get or wget
 
 Model source:
-https://github.com/onnx/models/blob/main/vision/classification/resnet/model/resnet50-v2-7.onnx
-https://github.com/onnx/models/blob/main/vision/classification/resnet/model/resnet50-v2-7.tar.gz
+https://github.com/onnx/models/blob/5faef4c33eba0395177850e1e31c4a6a9e634c82/vision/classification/resnet/model/resnet50-v2-7.onnx
+https://github.com/onnx/models/blob/5faef4c33eba0395177850e1e31c4a6a9e634c82/vision/classification/resnet/model/resnet50-v2-7.tar.gz
 
 Source of ground truth labels for validation set:
     ILSVRC2012_validation_ground_truth.txt


### PR DESCRIPTION
# Summary of Changes

* Update links for ONNX models

# Motivation

The ONNX repository is updating its models and layouts (see [this announcement](https://github.com/onnx/models/issues/616)). This updates the links to a fixed older commit which maintains the files in the original locations.

# Implementation

The chosen commit hash is the last hash before the ONNX repository moved files.

# Notes

N/A
